### PR TITLE
카테고리 목록 조회 API

### DIFF
--- a/src/main/java/com/wanted/safewallet/domain/category/business/mapper/CategoryMapper.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/business/mapper/CategoryMapper.java
@@ -1,0 +1,15 @@
+package com.wanted.safewallet.domain.category.business.mapper;
+
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    public CategoryListResponseDto toDto(List<Category> categoryList) {
+        List<String> categoryTypeList = categoryList.stream().map(c -> c.getType().name()).toList();
+        return new CategoryListResponseDto(categoryTypeList);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/category/business/service/CategoryService.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/business/service/CategoryService.java
@@ -1,0 +1,24 @@
+package com.wanted.safewallet.domain.category.business.service;
+
+import com.wanted.safewallet.domain.category.business.mapper.CategoryMapper;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.category.persistence.repository.CategoryRepository;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CategoryService {
+
+    private final CategoryMapper categoryMapper;
+    private final CategoryRepository categoryRepository;
+
+    public CategoryListResponseDto getCategoryList() {
+        List<Category> categoryList = categoryRepository.findAll();
+        return categoryMapper.toDto(categoryList);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/category/web/controller/CategoryController.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/web/controller/CategoryController.java
@@ -1,0 +1,23 @@
+package com.wanted.safewallet.domain.category.web.controller;
+
+import com.wanted.safewallet.domain.category.business.service.CategoryService;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+@RestController
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<CategoryListResponseDto> getCategoryList() {
+        CategoryListResponseDto dto = categoryService.getCategoryList();
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/category/web/dto/response/CategoryListResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/web/dto/response/CategoryListResponseDto.java
@@ -1,0 +1,12 @@
+package com.wanted.safewallet.domain.category.web.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryListResponseDto {
+
+    private List<String> categoryList;
+}

--- a/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
@@ -1,0 +1,51 @@
+package com.wanted.safewallet.domain.category.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.wanted.safewallet.domain.category.business.mapper.CategoryMapper;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.category.persistence.repository.CategoryRepository;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @InjectMocks
+    CategoryService categoryService;
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @Spy
+    CategoryMapper categoryMapper;
+
+    @DisplayName("전체 카테고리 조회 테스트 : 성공")
+    @Test
+    void getCategoryList() {
+        //given
+        List<Category> categoryList = List.of(Category.builder().type(CategoryType.FOOD).build(),
+            Category.builder().type(CategoryType.TRAFFIC).build());
+        given(categoryRepository.findAll()).willReturn(categoryList);
+
+        //when
+        CategoryListResponseDto dto = categoryService.getCategoryList();
+
+        //then
+        then(categoryRepository).should(times(1)).findAll();
+        then(categoryMapper).should(times(1)).toDto(categoryList);
+        assertThat(dto.getCategoryList()).hasSize(2);
+        assertThat(dto.getCategoryList()).contains(CategoryType.FOOD.name(), CategoryType.TRAFFIC.name());
+    }
+}

--- a/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
@@ -1,0 +1,49 @@
+package com.wanted.safewallet.domain.category.web.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.safewallet.domain.category.business.service.CategoryService;
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CategoryController.class)
+class CategoryControllerTest {
+
+    @MockBean
+    CategoryService categoryService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("카테고리 목록 조회 테스트 : 성공")
+    @Test
+    void getCategoryList() throws Exception {
+        //given
+        CategoryListResponseDto dto = new CategoryListResponseDto(
+            List.of(CategoryType.FOOD.name(), CategoryType.TRAFFIC.name()));
+        given(categoryService.getCategoryList()).willReturn(dto);
+
+        //when, then
+        mockMvc.perform(get("/api/categories")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.categoryList", hasSize(2)))
+            .andDo(print());
+        then(categoryService).should(times(1)).getCategoryList();
+    }
+}


### PR DESCRIPTION
## 🚀What's PR?
- 예산 설정에 사용할 수 있도록 모든 카테고리 목록 반환
- 카테고리 예: `식비`, `교통`, `주거`, `의류`, `여가`, `기타`

## ⚠️Concerns
카테고리 목록은 `식비`, `교통`과 같이 사용자에게 보이는 값이 아닌, `FOOD`, `TRAFFIC`과 같은 코드로 전송 (사용자에게 보이는 값에 대한 보다 유연한 변경을 위해)

<br/>

🎫**Jira Ticket Number**: [SW-2]