### PR TITLE
월별 예산 설정 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	//Querydsl
+	//Querydsl 의존성
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	//Jackson jsr310 의존성
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/wanted/safewallet/domain/budget/business/mapper/BudgetMapper.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/business/mapper/BudgetMapper.java
@@ -1,0 +1,32 @@
+package com.wanted.safewallet.domain.budget.business.mapper;
+
+import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto.BudgetByCategory;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.user.persistence.entity.User;
+import java.time.YearMonth;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BudgetMapper {
+
+    public List<Budget> toEntityList(String userId, BudgetSetUpRequestDto requestDto) {
+        YearMonth budgetYearMonth = requestDto.getBudgetYearMonth();
+        return requestDto.getBudgetList().stream().map(b -> Budget.builder()
+                .user(User.builder().id(userId).build())
+                .category(Category.builder().id(b.getCategoryId()).type(b.getType()).build())
+                .budgetYearMonth(budgetYearMonth).amount(b.getAmount()).build())
+            .toList();
+    }
+
+    public BudgetSetUpResponseDto toDto(List<Budget> budgetList) {
+        List<BudgetByCategory> budgetListByCategory = budgetList.stream()
+            .map(b -> new BudgetByCategory(b.getId(), b.getCategory().getId(),
+                b.getCategory().getType(), b.getAmount()))
+            .toList();
+        return new BudgetSetUpResponseDto(budgetListByCategory);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
@@ -1,0 +1,45 @@
+package com.wanted.safewallet.domain.budget.business.service;
+
+import com.wanted.safewallet.domain.budget.business.mapper.BudgetMapper;
+import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
+import com.wanted.safewallet.domain.budget.persistence.repository.BudgetRepository;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto.BudgetByCategory;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto;
+import com.wanted.safewallet.domain.category.business.dto.request.CategoryValidRequestDto;
+import com.wanted.safewallet.domain.category.business.service.CategoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class BudgetService {
+
+    private final BudgetMapper budgetMapper;
+    private final CategoryService categoryService;
+    private final BudgetRepository budgetRepository;
+
+    @Transactional
+    public BudgetSetUpResponseDto setUpBudget(String userId, BudgetSetUpRequestDto requestDto) {
+        validateRequest(userId, requestDto);
+        List<Budget> budgetList = budgetMapper.toEntityList(userId, requestDto);
+        budgetRepository.saveAll(budgetList);
+        return budgetMapper.toDto(budgetList);
+    }
+
+    private void validateRequest(String userId, BudgetSetUpRequestDto requestDto) {
+        List<CategoryValidRequestDto> categoryValidDtoList = requestDto.getBudgetList().stream()
+            .map(b -> new CategoryValidRequestDto(b.getCategoryId(), b.getType())).toList();
+        List<Long> categoryIds = requestDto.getBudgetList().stream().map(
+            BudgetByCategory::getCategoryId).toList();
+
+        categoryService.validateCategory(categoryValidDtoList);
+        if (budgetRepository.existsByUserIdAndBudgetYearMonthAndInCategories(
+            userId, requestDto.getBudgetYearMonth(), categoryIds)) {
+            throw new RuntimeException("해당 월, 해당 카테고리의 예산 설정이 이미 존재합니다.");
+        }
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepository.java
@@ -3,6 +3,6 @@ package com.wanted.safewallet.domain.budget.persistence.repository;
 import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BudgetRepository extends JpaRepository<Budget, Long> {
+public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRepositoryCustom {
 
 }

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.wanted.safewallet.domain.budget.persistence.repository;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface BudgetRepositoryCustom {
+
+    boolean existsByUserIdAndBudgetYearMonthAndInCategories(String userId,
+        YearMonth budgetYearMonth, List<Long> categoryIds);
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.wanted.safewallet.domain.budget.persistence.repository;
+
+import static com.wanted.safewallet.domain.budget.persistence.entity.QBudget.budget;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BudgetRepositoryImpl implements BudgetRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByUserIdAndBudgetYearMonthAndInCategories(String userId,
+        YearMonth budgetYearMonth, List<Long> categoryIds) {
+        return Boolean.TRUE.equals(queryFactory
+            .select(budgetCountCase())
+            .from(budget)
+            .where(budget.user.id.eq(userId),
+                budget.budgetYearMonth.eq(budgetYearMonth),
+                budget.category.id.in(categoryIds))
+            .fetchOne());
+    }
+
+    private BooleanExpression budgetCountCase() {
+        return new CaseBuilder()
+            .when(budget.count().gt(0)).then(true)
+            .otherwise(false);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/web/controller/BudgetController.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/web/controller/BudgetController.java
@@ -1,0 +1,31 @@
+package com.wanted.safewallet.domain.budget.web.controller;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/budgets")
+@RestController
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @Value("${temporary.userId}")
+    private String userId; //security 구현 전 임시 사용자 ID
+
+    @PostMapping
+    public ResponseEntity<BudgetSetUpResponseDto> setUpBudget(@RequestBody @Valid BudgetSetUpRequestDto requestDto) {
+        BudgetSetUpResponseDto responseDto = budgetService.setUpBudget(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/web/dto/request/BudgetSetUpRequestDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/web/dto/request/BudgetSetUpRequestDto.java
@@ -1,0 +1,35 @@
+package com.wanted.safewallet.domain.budget.web.dto.request;
+
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class BudgetSetUpRequestDto {
+
+    @FutureOrPresent
+    @NotNull
+    private YearMonth budgetYearMonth; //TODO: 날짜 매핑
+
+    @Valid
+    @NotEmpty
+    private List<BudgetByCategory> budgetList;
+
+    @Getter
+    public static class BudgetByCategory {
+
+        @NotNull
+        private Long categoryId;
+
+        @NotNull
+        private CategoryType type; //TODO: Enum 매핑
+
+        @NotNull
+        private Long amount;
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/budget/web/dto/request/BudgetSetUpRequestDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/web/dto/request/BudgetSetUpRequestDto.java
@@ -7,9 +7,13 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.YearMonth;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BudgetSetUpRequestDto {
 
     @FutureOrPresent
@@ -21,6 +25,8 @@ public class BudgetSetUpRequestDto {
     private List<BudgetByCategory> budgetList;
 
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class BudgetByCategory {
 
         @NotNull

--- a/src/main/java/com/wanted/safewallet/domain/budget/web/dto/response/BudgetSetUpResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/web/dto/response/BudgetSetUpResponseDto.java
@@ -1,0 +1,23 @@
+package com.wanted.safewallet.domain.budget.web.dto.response;
+
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BudgetSetUpResponseDto {
+
+    private List<BudgetByCategory> budgetList;
+
+    @Getter
+    @AllArgsConstructor
+    public static class BudgetByCategory {
+
+        private Long budgetId;
+        private Long categoryId;
+        private CategoryType type;
+        private Long amount;
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/category/business/dto/request/CategoryValidRequestDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/business/dto/request/CategoryValidRequestDto.java
@@ -1,0 +1,13 @@
+package com.wanted.safewallet.domain.category.business.dto.request;
+
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryValidRequestDto {
+
+    private Long categoryId;
+    private CategoryType type;
+}

--- a/src/main/java/com/wanted/safewallet/domain/category/business/mapper/CategoryMapper.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/business/mapper/CategoryMapper.java
@@ -2,6 +2,7 @@ package com.wanted.safewallet.domain.category.business.mapper;
 
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto.CategoryResponseDto;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +10,8 @@ import org.springframework.stereotype.Component;
 public class CategoryMapper {
 
     public CategoryListResponseDto toDto(List<Category> categoryList) {
-        List<String> categoryTypeList = categoryList.stream().map(c -> c.getType().name()).toList();
-        return new CategoryListResponseDto(categoryTypeList);
+        return new CategoryListResponseDto(categoryList.stream()
+            .map(c -> new CategoryResponseDto(c.getId(), c.getType()))
+            .toList());
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/category/business/service/CategoryService.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/business/service/CategoryService.java
@@ -1,10 +1,12 @@
 package com.wanted.safewallet.domain.category.business.service;
 
+import com.wanted.safewallet.domain.category.business.dto.request.CategoryValidRequestDto;
 import com.wanted.safewallet.domain.category.business.mapper.CategoryMapper;
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.category.persistence.repository.CategoryRepository;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,5 +22,19 @@ public class CategoryService {
     public CategoryListResponseDto getCategoryList() {
         List<Category> categoryList = categoryRepository.findAll();
         return categoryMapper.toDto(categoryList);
+    }
+
+    public void validateCategory(List<CategoryValidRequestDto> requestDtoList) {
+        Map<Long, Category> categoryMap = categoryRepository.findAllMap();
+        requestDtoList.forEach(category -> {
+            if (!existsCategory(categoryMap, category)) {
+                throw new RuntimeException("존재하지 않는 카테고리입니다.");
+            }
+        });
+    }
+
+    private boolean existsCategory(Map<Long, Category> categoryMap, CategoryValidRequestDto category) {
+        return categoryMap.containsKey(category.getCategoryId())
+            && categoryMap.get(category.getCategoryId()).getType() == category.getType();
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/category/persistence/repository/CategoryRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/persistence/repository/CategoryRepository.java
@@ -1,8 +1,17 @@
 package com.wanted.safewallet.domain.category.persistence.repository;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import java.util.List;
+import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    default Map<Long, Category> findAllMap() {
+        List<Category> categoryList = findAll();
+        return categoryList.stream().collect(toMap(Category::getId, identity()));
+    }
 }

--- a/src/main/java/com/wanted/safewallet/domain/category/web/controller/CategoryController.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/web/controller/CategoryController.java
@@ -17,7 +17,7 @@ public class CategoryController {
 
     @GetMapping
     public ResponseEntity<CategoryListResponseDto> getCategoryList() {
-        CategoryListResponseDto dto = categoryService.getCategoryList();
-        return ResponseEntity.ok(dto);
+        CategoryListResponseDto responseDto = categoryService.getCategoryList();
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/category/web/dto/response/CategoryListResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/category/web/dto/response/CategoryListResponseDto.java
@@ -1,5 +1,6 @@
 package com.wanted.safewallet.domain.category.web.dto.response;
 
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,5 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CategoryListResponseDto {
 
-    private List<String> categoryList;
+    private List<CategoryResponseDto> categoryList;
+
+    @Getter
+    @AllArgsConstructor
+    public static class CategoryResponseDto {
+
+        private Long categoryId;
+        private CategoryType type;
+    }
 }

--- a/src/main/java/com/wanted/safewallet/global/config/QuerydslConfig.java
+++ b/src/main/java/com/wanted/safewallet/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.safewallet.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,6 @@ logging:
   level:
     org.hibernate.sql: info
     org.hibernate.type.descriptor.sql: trace
+
+temporary:
+  userId: ${USER_ID}

--- a/src/test/java/com/wanted/safewallet/domain/budget/business/service/BudgetServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/budget/business/service/BudgetServiceTest.java
@@ -1,0 +1,92 @@
+package com.wanted.safewallet.domain.budget.business.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.wanted.safewallet.domain.budget.business.mapper.BudgetMapper;
+import com.wanted.safewallet.domain.budget.persistence.repository.BudgetRepository;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto.BudgetByCategory;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto;
+import com.wanted.safewallet.domain.category.business.service.CategoryService;
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetServiceTest {
+
+    @InjectMocks
+    BudgetService budgetService;
+
+    @Mock
+    CategoryService categoryService;
+
+    @Mock
+    BudgetRepository budgetRepository;
+
+    @Spy
+    BudgetMapper budgetMapper;
+
+    @DisplayName("월별 예산 설정 서비스 테스트 : 성공")
+    @Test
+    void setUpBudget() {
+        //given
+        given(budgetRepository.existsByUserIdAndBudgetYearMonthAndInCategories(
+            anyString(), any(YearMonth.class), anyList())).willReturn(false);
+
+        //when
+        String userId = "testUserId";
+        BudgetSetUpRequestDto requestDto = new BudgetSetUpRequestDto(YearMonth.of(2023, 11),
+            List.of(new BudgetByCategory(1L, CategoryType.FOOD, 10000L),
+                new BudgetByCategory(2L, CategoryType.TRAFFIC, 5000L)));
+        BudgetSetUpResponseDto responseDto = budgetService.setUpBudget(userId, requestDto);
+
+        //then
+        then(categoryService).should(times(1)).validateCategory(anyList());
+        then(budgetRepository).should(times(1))
+            .existsByUserIdAndBudgetYearMonthAndInCategories(anyString(), any(YearMonth.class), anyList());
+        then(budgetRepository).should(times(1)).saveAll(anyList());
+
+        assertThat(responseDto.getBudgetList()).hasSize(2);
+        assertThat(responseDto.getBudgetList()).extracting("categoryId").contains(1L, 2L);
+        assertThat(responseDto.getBudgetList()).extracting("type")
+            .contains(CategoryType.FOOD, CategoryType.TRAFFIC);
+        assertThat(responseDto.getBudgetList()).extracting("amount").contains(10000L, 5000L);
+    }
+
+    @DisplayName("월별 예산 설정 서비스 테스트 : 실패 - 같은 날짜, 같은 카테고리의 기존 예산 설정 내역 존재")
+    @Test
+    void setUpBudgetFail() {
+        //given
+        given(budgetRepository.existsByUserIdAndBudgetYearMonthAndInCategories(
+            anyString(), any(YearMonth.class), anyList())).willReturn(true);
+
+        //when
+        String userId = "testUserId";
+        BudgetSetUpRequestDto requestDto = new BudgetSetUpRequestDto(YearMonth.of(2023, 11),
+            List.of(new BudgetByCategory(1L, CategoryType.FOOD, 10000L),
+                new BudgetByCategory(2L, CategoryType.TRAFFIC, 5000L)));
+
+        //then
+        assertThatThrownBy(() -> budgetService.setUpBudget(userId, requestDto))
+                .isInstanceOf(RuntimeException.class);
+        then(categoryService).should(times(1)).validateCategory(anyList());
+        then(budgetRepository).should(times(1))
+            .existsByUserIdAndBudgetYearMonthAndInCategories(anyString(), any(YearMonth.class), anyList());
+        then(budgetRepository).should(times(0)).saveAll(anyList());
+    }
+}

--- a/src/test/java/com/wanted/safewallet/domain/budget/web/controller/BudgetControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/budget/web/controller/BudgetControllerTest.java
@@ -1,0 +1,64 @@
+package com.wanted.safewallet.domain.budget.web.controller;
+
+import static com.wanted.safewallet.utils.JsonUtils.asJsonString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.budget.web.dto.request.BudgetSetUpRequestDto;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto;
+import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponseDto.BudgetByCategory;
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BudgetController.class)
+class BudgetControllerTest {
+
+    @MockBean
+    BudgetService budgetService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("월별 예산 설정 컨트롤러 테스트 : 성공")
+    @Test
+    void setUpBudget() throws Exception {
+        //given
+        BudgetSetUpResponseDto responseDto = new BudgetSetUpResponseDto(List.of(
+            new BudgetByCategory(1L, 1L, CategoryType.FOOD, 10000L),
+            new BudgetByCategory(2L, 2L, CategoryType.TRAFFIC, 5000L)));
+        given(budgetService.setUpBudget(anyString(), any(BudgetSetUpRequestDto.class))).willReturn(responseDto);
+
+        //when, then
+        BudgetSetUpRequestDto requestDto = new BudgetSetUpRequestDto(YearMonth.of(2023, 11),
+            List.of(new BudgetSetUpRequestDto.BudgetByCategory(1L, CategoryType.FOOD, 10000L),
+                new BudgetSetUpRequestDto.BudgetByCategory(2L, CategoryType.TRAFFIC, 5000L)));
+        mockMvc.perform(post("/api/budgets")
+                .content(asJsonString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.budgetList", hasSize(2)))
+            .andDo(print());
+        then(budgetService).should(times(1))
+            .setUpBudget(anyString(), any(BudgetSetUpRequestDto.class));
+    }
+    
+    //TODO: validation 실패 테스트 작성
+}

--- a/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
@@ -1,16 +1,19 @@
 package com.wanted.safewallet.domain.category.business.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import com.wanted.safewallet.domain.category.business.dto.request.CategoryValidRequestDto;
 import com.wanted.safewallet.domain.category.business.mapper.CategoryMapper;
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import com.wanted.safewallet.domain.category.persistence.repository.CategoryRepository;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,5 +55,24 @@ class CategoryServiceTest {
         assertThat(responseDto.getCategoryList())
             .extracting("type")
             .contains(CategoryType.FOOD, CategoryType.TRAFFIC);
+    }
+
+    @DisplayName("카테고리 유효성 검증 테스트 : 실패 - 존재하지 않는 카테고리")
+    @Test
+    void validateCategoryFail() {
+        //given
+        Map<Long, Category> categoryMap = Map.of(
+            1L, Category.builder().id(1L).type(CategoryType.FOOD).build(),
+            2L, Category.builder().id(2L).type(CategoryType.TRAFFIC).build());
+        given(categoryRepository.findAllMap()).willReturn(categoryMap);
+
+        //when
+        List<CategoryValidRequestDto> categoryValidRequestDtoList = List.of(
+            new CategoryValidRequestDto(1L, CategoryType.TRAFFIC));
+
+        //then
+        assertThatThrownBy(() -> categoryService.validateCategory(categoryValidRequestDtoList))
+            .isInstanceOf(RuntimeException.class);
+        then(categoryRepository).should(times(1)).findAllMap();
     }
 }

--- a/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/business/service/CategoryServiceTest.java
@@ -35,17 +35,22 @@ class CategoryServiceTest {
     @Test
     void getCategoryList() {
         //given
-        List<Category> categoryList = List.of(Category.builder().type(CategoryType.FOOD).build(),
-            Category.builder().type(CategoryType.TRAFFIC).build());
+        List<Category> categoryList = List.of(Category.builder().id(1L).type(CategoryType.FOOD).build(),
+            Category.builder().id(2L).type(CategoryType.TRAFFIC).build());
         given(categoryRepository.findAll()).willReturn(categoryList);
 
         //when
-        CategoryListResponseDto dto = categoryService.getCategoryList();
+        CategoryListResponseDto responseDto = categoryService.getCategoryList();
 
         //then
         then(categoryRepository).should(times(1)).findAll();
         then(categoryMapper).should(times(1)).toDto(categoryList);
-        assertThat(dto.getCategoryList()).hasSize(2);
-        assertThat(dto.getCategoryList()).contains(CategoryType.FOOD.name(), CategoryType.TRAFFIC.name());
+        assertThat(responseDto.getCategoryList()).hasSize(2);
+        assertThat(responseDto.getCategoryList())
+            .extracting("categoryId")
+            .contains(1L, 2L);
+        assertThat(responseDto.getCategoryList())
+            .extracting("type")
+            .contains(CategoryType.FOOD, CategoryType.TRAFFIC);
     }
 }

--- a/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.wanted.safewallet.domain.category.business.service.CategoryService;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto;
+import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponseDto.CategoryResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ class CategoryControllerTest {
     void getCategoryList() throws Exception {
         //given
         CategoryListResponseDto dto = new CategoryListResponseDto(
-            List.of(CategoryType.FOOD.name(), CategoryType.TRAFFIC.name()));
+            List.of(new CategoryResponseDto(1L, CategoryType.FOOD),
+                new CategoryResponseDto(2L, CategoryType.TRAFFIC)));
         given(categoryService.getCategoryList()).willReturn(dto);
 
         //when, then

--- a/src/test/java/com/wanted/safewallet/utils/JsonUtils.java
+++ b/src/test/java/com/wanted/safewallet/utils/JsonUtils.java
@@ -1,0 +1,16 @@
+package com.wanted.safewallet.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class JsonUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private JsonUtils() {}
+
+    public static String asJsonString(Object value) throws JsonProcessingException {
+        return objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(value);
+    }
+}


### PR DESCRIPTION
## 🚀What's PR?

- 월별, 카테고리 별 예산 설정 
- 오늘 날짜 이후의 예산 설정만 가능 → Bean Validation 어노테이션(`@FutureOrPresent`) 사용
- 유효한 카테고리인지 확인 → `CategoryService`에게 위임
- 같은 날짜, 같은 카테고리의 기존 예산 설정 내역이 있다면 설정 불가 → `Exception` throw (예외처리 추후 구현)

## ⚠️Concerns

- 같은 날짜, 같은 카테고리의 기존 예산 설정 내역이 있다면 설정 불가가 아닌 다른 로직으로 동작? **for 사용자 친화성**

<br/>

🎫**Jira Ticket Number**: [SW-12]

[SW-12]: https://jkde7721.atlassian.net/browse/SW-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ