### PR TITLE
오늘 지출 추천 API

### DIFF
--- a/src/docs/asciidoc/category-type.adoc
+++ b/src/docs/asciidoc/category-type.adoc
@@ -1,2 +1,2 @@
 [[category-type]]
-include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-categoryType.adoc[]
+include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-CategoryType.adoc[]

--- a/src/docs/asciidoc/expenditure-api.adoc
+++ b/src/docs/asciidoc/expenditure-api.adoc
@@ -57,3 +57,13 @@ operation::expenditure-controller-test/delete-expenditure[snippets="response-bod
 - `지난 주`: 현재 `2023-12-06` 이라면, `2023-11-27 ~ 2023-11-29` 대비 `2023-12-04 ~ 2023-12-06` 소비율 (한 주는 `월 ~ 일`)
 
 operation::expenditure-controller-test/produce-expenditure-stats[snippets="http-request,query-parameters,response-body,response-fields-data"]
+
+=== 오늘 지출 추천 API
+==== `GET /api/expenditures/consult`
+
+- 설정한 월별 예산을 만족하기 위해 오늘 지출 가능한 금액을 `총액` 과 `카테고리 별 금액` 으로 제공
+- `절약하여 소비한 경우`, `예산에 맞게 소비한 경우`, `예산 초과 위험이 있는 경우`, `현재까지의 지출이 예산을 초과한 경우` 등 유저의 상황에 맞는 메세지를 같이 노출 ex. `EXCELLENT`, `GOOD`, `WARN`, `BAD`
+- `15333원` 같은 값이라면 백원 단위 반올림으로 사용자 친화적으로 변환
+- 특정 시간에 Discord webhook, 이메일, 카카오톡 등 알림 발송 (추후 구현 예정)
+
+operation::expenditure-controller-test/consult-today-expenditure[snippets="response-body,response-fields-data"]

--- a/src/docs/asciidoc/finance-status.adoc
+++ b/src/docs/asciidoc/finance-status.adoc
@@ -1,2 +1,2 @@
 [[finance-status]]
-include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-financeStatus.adoc[]
+include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-FinanceStatus.adoc[]

--- a/src/docs/asciidoc/finance-status.adoc
+++ b/src/docs/asciidoc/finance-status.adoc
@@ -1,0 +1,2 @@
+[[finance-status]]
+include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-financeStatus.adoc[]

--- a/src/docs/asciidoc/stats-criteria.adoc
+++ b/src/docs/asciidoc/stats-criteria.adoc
@@ -1,2 +1,2 @@
 [[stats-criteria]]
-include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-statsCriteria.adoc[]
+include::{snippets}/enum-docs-controller-test/get-enums/enum-fields-StatsCriteria.adoc[]

--- a/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
@@ -75,8 +75,8 @@ public class BudgetService {
         return budgetMapper.toDto(budgetAmountByCategory);
     }
 
-    public List<Budget> getBudgetListWithCategoryInYearMonth(String userId, YearMonth budgetYearMonth) {
-        return budgetRepository.findByUserAndBudgetYearMonthFetch(userId, budgetYearMonth);
+    public Map<Category, Long> getBudgetTotalAmountByCategory(String userId, YearMonth budgetYearMonth) {
+        return budgetRepository.findTotalAmountMapByUserAndBudgetYearMonth(userId, budgetYearMonth);
     }
 
     public Budget getValidBudget(String userId, Long budgetId) {

--- a/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
@@ -20,6 +20,7 @@ import com.wanted.safewallet.domain.category.business.service.CategoryService;
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import com.wanted.safewallet.global.exception.BusinessException;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,6 +73,10 @@ public class BudgetService {
                 budgetRepository.getTotalAmountByCategoryList();
         Map<Category, Long> budgetAmountByCategory = consultBudgetAmount(totalAmountForConsult, totalAmountByCategoryList);
         return budgetMapper.toDto(budgetAmountByCategory);
+    }
+
+    public List<Budget> getBudgetListWithCategoryInYearMonth(String userId, YearMonth budgetYearMonth) {
+        return budgetRepository.findByUserAndBudgetYearMonthFetch(userId, budgetYearMonth);
     }
 
     public Budget getValidBudget(String userId, Long budgetId) {

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.wanted.safewallet.domain.budget.persistence.repository;
 
 import com.wanted.safewallet.domain.budget.persistence.dto.response.TotalAmountByCategoryResponseDto;
-import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 
 public interface BudgetRepositoryCustom {
 
@@ -14,5 +15,5 @@ public interface BudgetRepositoryCustom {
 
     List<TotalAmountByCategoryResponseDto> getTotalAmountByCategoryList();
 
-    List<Budget> findByUserAndBudgetYearMonthFetch(String userId, YearMonth budgetYearMonth);
+    Map<Category, Long> findTotalAmountMapByUserAndBudgetYearMonth(String userId, YearMonth budgetYearMonth);
 }

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.wanted.safewallet.domain.budget.persistence.repository;
 
 import com.wanted.safewallet.domain.budget.persistence.dto.response.TotalAmountByCategoryResponseDto;
+import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -12,4 +13,6 @@ public interface BudgetRepositoryCustom {
     List<TotalAmountByCategoryResponseDto> getTotalAmountByCategoryList(String userId);
 
     List<TotalAmountByCategoryResponseDto> getTotalAmountByCategoryList();
+
+    List<Budget> findByUserAndBudgetYearMonthFetch(String userId, YearMonth budgetYearMonth);
 }

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryImpl.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepositoryImpl.java
@@ -9,9 +9,11 @@ import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wanted.safewallet.domain.budget.persistence.dto.response.TotalAmountByCategoryResponseDto;
-import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -48,14 +50,16 @@ public class BudgetRepositoryImpl implements BudgetRepositoryCustom {
     }
 
     @Override
-    public List<Budget> findByUserAndBudgetYearMonthFetch(String userId, YearMonth budgetYearMonth) {
-        return queryFactory.select(constructor(Budget.class,
-                budget.id, budget.user, budget.category,
-                budget.amount.coalesce(0L), budget.budgetYearMonth))
+    public Map<Category, Long> findTotalAmountMapByUserAndBudgetYearMonth(String userId, YearMonth budgetYearMonth) {
+        return queryFactory.select(category, budget.amount.coalesce(0L).sum())
             .from(budget)
             .rightJoin(budget.category, category)
             .on(userIdEq(userId), budgetYearMonthEq(budgetYearMonth))
-            .fetch();
+            .groupBy(category.id)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(tuple -> tuple.get(category),
+                tuple -> tuple.get(1, Long.class)));
     }
 
     private BooleanExpression budgetCountCase() {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/mapper/ExpenditureMapper.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/mapper/ExpenditureMapper.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureConsultVo;
 import com.wanted.safewallet.domain.expenditure.persistence.dto.response.StatsByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureCreateRequestDto;
@@ -15,7 +16,10 @@ import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSear
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSearchExceptsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto.ConsumptionRateByCategoryResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto.TodayExpenditureConsultOfCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TotalAmountByCategoryResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
 import com.wanted.safewallet.domain.user.persistence.entity.User;
 import com.wanted.safewallet.global.dto.response.PageResponse;
 import java.time.LocalDate;
@@ -119,5 +123,17 @@ public class ExpenditureMapper {
                 .note(expenditure.getNote())
                 .build())
             .toList();
+    }
+
+    public TodayExpenditureConsultResponseDto toDto(long todayTotalAmount, FinanceStatus totalFinanceStatus,
+        Map<Category, TodayExpenditureConsultVo> todayExpenditureConsultByCategory) {
+        List<TodayExpenditureConsultOfCategoryResponseDto> todayExpenditureConsultOfCategoryList =
+            todayExpenditureConsultByCategory.keySet().stream()
+                .sorted(Comparator.comparing(Category::getId))
+                .map(category -> new TodayExpenditureConsultOfCategoryResponseDto(category.getId(), category.getType(),
+                    todayExpenditureConsultByCategory.get(category).todayTotalAmount(),
+                    todayExpenditureConsultByCategory.get(category).financeStatus()))
+                .toList();
+        return new TodayExpenditureConsultResponseDto(todayTotalAmount, totalFinanceStatus, todayExpenditureConsultOfCategoryList);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
@@ -1,0 +1,118 @@
+package com.wanted.safewallet.domain.expenditure.business.service;
+
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.BAD;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.EXCELLENT;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.GOOD;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.WARN;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureConsultVo;
+import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ExpenditureConsultService {
+
+    private final ExpenditureMapper expenditureMapper;
+    private final BudgetService budgetService;
+    private final ExpenditureRepository expenditureRepository;
+
+    public TodayExpenditureConsultResponseDto consultTodayExpenditure(String userId) {
+        LocalDate expenditureEndDate = LocalDate.now();
+        YearMonth currentYearMonth = YearMonth.of(expenditureEndDate.getYear(), expenditureEndDate.getMonth());
+        LocalDate expenditureStartDate = currentYearMonth.atDay(1);
+        int daysOfCurrentMonth = currentYearMonth.lengthOfMonth();
+        int leftDaysOfCurrentMonth = daysOfCurrentMonth - expenditureEndDate.getDayOfMonth() + 1;
+        //월별 총 예산 (카테고리 별)
+        Map<Category, Long> budgetTotalAmountByCategory = budgetService.getBudgetTotalAmountByCategory(userId, currentYearMonth);
+        //일별 적정 예산 (카테고리 별)
+        Map<Category, Long> budgetAmountPerDayByCategory = getBudgetAmountPerDayByCategory(budgetTotalAmountByCategory, daysOfCurrentMonth);
+        //현재 월 내에서 현재까지 총 지출 (카테고리 별)
+        Map<Category, Long> expenditureTotalAmountByCategory = expenditureRepository.findTotalAmountMapByUserAndExpenditureDateRange(
+            userId, expenditureStartDate, expenditureEndDate);
+        //현재 월 내에서 남은 기간 동안 일별 적정 지출 (카테고리 별)
+        Map<Category, Long> expenditureAmountPerDayByCategory = getExpenditureAmountPerDayByCategory(
+            expenditureTotalAmountByCategory, budgetTotalAmountByCategory, budgetAmountPerDayByCategory, leftDaysOfCurrentMonth);
+
+        long todayTotalAmount = calculateTodayTotalAmount(expenditureAmountPerDayByCategory);
+        FinanceStatus totalFinanceStatus = getTotalFinanceStatus(budgetTotalAmountByCategory, budgetAmountPerDayByCategory, expenditureTotalAmountByCategory, expenditureEndDate);
+        Map<Category, TodayExpenditureConsultVo> todayExpenditureConsultByCategory =
+            getTodayExpenditureConsultByCategory(budgetTotalAmountByCategory, budgetAmountPerDayByCategory, expenditureTotalAmountByCategory, expenditureAmountPerDayByCategory);
+        return expenditureMapper.toDto(todayTotalAmount, totalFinanceStatus, todayExpenditureConsultByCategory);
+    }
+
+    private Map<Category, Long> getBudgetAmountPerDayByCategory(Map<Category, Long> budgetTotalAmountByCategory, int daysOfCurrentMonth) {
+        return budgetTotalAmountByCategory.keySet().stream().collect(toMap(identity(), category ->
+            calculateAmountPerDay(budgetTotalAmountByCategory.get(category), daysOfCurrentMonth)));
+    }
+
+    private Map<Category, Long> getExpenditureAmountPerDayByCategory(
+        Map<Category, Long> expenditureTotalAmountByCategory,
+        Map<Category, Long> budgetTotalAmountByCategory, Map<Category, Long> budgetAmountPerDayByCategory,
+        int leftDaysOfCurrentMonth) {
+        return expenditureTotalAmountByCategory.keySet().stream().collect(toMap(identity(), category ->
+            calculateExpenditureAmountPerDay(budgetTotalAmountByCategory.get(category) - expenditureTotalAmountByCategory.get(category),
+                budgetAmountPerDayByCategory.get(category), leftDaysOfCurrentMonth)));
+    }
+
+    private Long calculateExpenditureAmountPerDay(Long leftBudgetTotalAmount, Long budgetAmountPerDay, int days) {
+        long expenditureAmountPerDay = calculateAmountPerDay(leftBudgetTotalAmount, days);
+        return expenditureAmountPerDay < 100 ? budgetAmountPerDay : expenditureAmountPerDay;
+    }
+
+    private Long calculateAmountPerDay(Long totalAmount, int days) {
+        return (long) ((double) totalAmount / days / 100) * 100; //100원 단위로 환산
+    }
+
+    private long calculateTodayTotalAmount(Map<Category, Long> expenditureAmountPerDayByCategory) {
+        return expenditureAmountPerDayByCategory.values().stream().mapToLong(Long::longValue).sum();
+    }
+
+    private FinanceStatus getTotalFinanceStatus(Map<Category, Long> budgetTotalAmountByCategory,
+        Map<Category, Long> budgetAmountPerDayByCategory, Map<Category, Long> expenditureTotalAmountByCategory, LocalDate now) {
+        long budgetTotalAmount = budgetTotalAmountByCategory.values().stream().mapToLong(Long::longValue).sum();
+        long budgetTotalAmountToNow = budgetAmountPerDayByCategory.values().stream().mapToLong(Long::longValue).sum() * now.getDayOfMonth();
+        long expenditureTotalAmountToNow = expenditureTotalAmountByCategory.values().stream().mapToLong(Long::longValue).sum();
+        return getFinanceStatus(budgetTotalAmount, expenditureTotalAmountToNow,
+            budgetTotalAmountToNow, expenditureTotalAmountToNow);
+    }
+
+    private Map<Category, TodayExpenditureConsultVo> getTodayExpenditureConsultByCategory(
+        Map<Category, Long> budgetTotalAmountByCategory, Map<Category, Long> budgetAmountPerDayByCategory,
+        Map<Category, Long> expenditureTotalAmountByCategory, Map<Category, Long> expenditureAmountPerDayByCategory) {
+        return expenditureAmountPerDayByCategory.keySet().stream()
+            .collect(toMap(identity(), category -> new TodayExpenditureConsultVo(
+                expenditureAmountPerDayByCategory.get(category),
+                getFinanceStatus(budgetTotalAmountByCategory.get(category),
+                    expenditureTotalAmountByCategory.get(category),
+                    budgetAmountPerDayByCategory.get(category),
+                    expenditureAmountPerDayByCategory.get(category)))));
+    }
+
+    private FinanceStatus getFinanceStatus(long budgetTotalAmount, long expenditureTotalAmount,
+        long budgetAmountPerDay, long expenditureAmountPerDay) {
+        if (budgetTotalAmount < expenditureTotalAmount) return BAD; //예산 초과
+        Long toleranceAmount = calculateToleranceAmount(budgetAmountPerDay);
+        if (budgetAmountPerDay - toleranceAmount > expenditureAmountPerDay) return WARN;
+        if (budgetAmountPerDay - toleranceAmount <= expenditureAmountPerDay &&
+            budgetAmountPerDay + toleranceAmount >= expenditureAmountPerDay) return GOOD;
+        return EXCELLENT;
+    }
+
+    private Long calculateToleranceAmount(long amount) {
+        return (long) (amount * 0.1); //TODO: 허용 오차 금액 정확도
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
@@ -86,8 +86,13 @@ public class ExpenditureConsultService {
         long budgetTotalAmount = budgetTotalAmountByCategory.values().stream().mapToLong(Long::longValue).sum();
         long budgetTotalAmountToNow = budgetAmountPerDayByCategory.values().stream().mapToLong(Long::longValue).sum() * now.getDayOfMonth();
         long expenditureTotalAmountToNow = expenditureTotalAmountByCategory.values().stream().mapToLong(Long::longValue).sum();
-        return getFinanceStatus(budgetTotalAmount, expenditureTotalAmountToNow,
-            budgetTotalAmountToNow, expenditureTotalAmountToNow);
+
+        if (budgetTotalAmount < expenditureTotalAmountToNow) return BAD; //예산 초과
+        Long toleranceAmount = calculateToleranceAmount(budgetTotalAmountToNow);
+        if (budgetTotalAmountToNow + toleranceAmount < expenditureTotalAmountToNow) return WARN;
+        if (budgetTotalAmountToNow - toleranceAmount <= expenditureTotalAmountToNow &&
+            budgetTotalAmountToNow + toleranceAmount >= expenditureTotalAmountToNow) return GOOD;
+        return EXCELLENT;
     }
 
     private Map<Category, TodayExpenditureConsultVo> getTodayExpenditureConsultByCategory(

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/TodayExpenditureConsultVo.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/TodayExpenditureConsultVo.java
@@ -1,0 +1,6 @@
+package com.wanted.safewallet.domain.expenditure.business.vo;
+
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
+
+public record TodayExpenditureConsultVo(Long todayTotalAmount, FinanceStatus financeStatus) {
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryCustom.java
@@ -1,11 +1,13 @@
 package com.wanted.safewallet.domain.expenditure.persistence.repository;
 
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.expenditure.persistence.dto.response.StatsByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.persistence.dto.response.TotalAmountByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureSearchCond;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,4 +20,6 @@ public interface ExpenditureRepositoryCustom {
     Page<Expenditure> findAllFetch(String userId, ExpenditureSearchCond searchCond, Pageable pageable);
 
     List<TotalAmountByCategoryResponseDto> getTotalAmountByCategoryList(String userId, LocalDate startDate, LocalDate endDate);
+
+    Map<Category, Long> findTotalAmountMapByUserAndExpenditureDateRange(String userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryImpl.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryImpl.java
@@ -77,16 +77,21 @@ public class ExpenditureRepositoryImpl implements ExpenditureRepositoryCustom {
                 category, expenditure.amount.coalesce(0L).sum()))
             .from(expenditure)
             .rightJoin(expenditure.category, category)
-            .on(userIdEq(userId), expenditureDateBetween(startDate, endDate))
+            .on(userIdEq(userId), expenditureDateBetween(startDate, endDate), notDeleted())
             .groupBy(category.id)
             .fetch();
+    }
+
+    private BooleanExpression notDeleted() {
+        return expenditure.deleted.isFalse();
     }
 
     private BooleanExpression expenditureSearchExpression(String userId, ExpenditureSearchCond searchCond) {
         return userIdEq(userId)
             .and(expenditureDateBetween(searchCond.getStartDate(), searchCond.getEndDate()))
             .and(categoryIdIn(searchCond.getCategories()))
-            .and(amountBetween(searchCond.getMinAmount(), searchCond.getMaxAmount()));
+            .and(amountBetween(searchCond.getMinAmount(), searchCond.getMaxAmount()))
+            .and(notDeleted());
     }
 
     private BooleanExpression userIdEq(String userId) {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureController.java
@@ -1,5 +1,6 @@
 package com.wanted.safewallet.domain.expenditure.web.controller;
 
+import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureConsultService;
 import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureService;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureCreateRequestDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureSearchCond;
@@ -9,6 +10,7 @@ import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureDeta
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSearchResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSearchExceptsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
 import com.wanted.safewallet.global.auth.annotation.CurrentUserId;
 import com.wanted.safewallet.global.dto.response.aop.CommonResponseContent;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExpenditureController {
 
     private final ExpenditureService expenditureService;
+    private final ExpenditureConsultService expenditureConsultService;
 
     @GetMapping("/{expenditureId}")
     public ExpenditureDetailsResponseDto getExpenditureDetails(@PathVariable Long expenditureId,
@@ -76,5 +79,10 @@ public class ExpenditureController {
     public ExpenditureStatsResponseDto produceExpenditureStats(@CurrentUserId String userId,
         @RequestParam(defaultValue = "LAST_MONTH") StatsCriteria criteria) {
         return expenditureService.produceExpenditureStats(userId, criteria);
+    }
+
+    @GetMapping("/consult")
+    public TodayExpenditureConsultResponseDto consultTodayExpenditure(@CurrentUserId String userId) {
+        return expenditureConsultService.consultTodayExpenditure(userId);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureConsultResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureConsultResponseDto.java
@@ -1,0 +1,31 @@
+package com.wanted.safewallet.domain.expenditure.web.dto.response;
+
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TodayExpenditureConsultResponseDto {
+
+    private Long todayTotalAmount;
+
+    private FinanceStatus totalFinanceStatus;
+
+    private List<TodayExpenditureConsultOfCategoryResponseDto> todayExpenditureConsultOfCategoryList;
+
+    @Getter
+    @AllArgsConstructor
+    public static class TodayExpenditureConsultOfCategoryResponseDto {
+
+        private Long categoryId;
+
+        private CategoryType type;
+
+        private Long todayTotalAmount;
+
+        private FinanceStatus financeStatus;
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/enums/FinanceStatus.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/enums/FinanceStatus.java
@@ -1,0 +1,23 @@
+package com.wanted.safewallet.domain.expenditure.web.enums;
+
+import com.wanted.safewallet.global.enums.EnumType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FinanceStatus implements EnumType {
+
+    EXCELLENT("절약하여 소비한 경우"), GOOD("예산에 맞게 소비한 경우"),
+    WARN("예산 초과 위험이 있는 경우"), BAD("현재까지의 지출이 예산을 초과한 경우");
+
+    private final String description;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/src/test/java/com/wanted/safewallet/docs/common/DocsPopupLinkGenerator.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/DocsPopupLinkGenerator.java
@@ -13,6 +13,7 @@ public abstract class DocsPopupLinkGenerator {
     public enum DocsPopupInfo {
         CATEGORY_TYPE("category-type", "카테고리 타입"),
         STATS_CRITERIA("stats-criteria", "지출 통계 기준"),
+        FINANCE_STATUS("finance-status", "예산 대비 지출에 따른 재정 상태"),
         PAGING_RESPONSE("paging-response", "페이징 응답"),
         PASSWORD_CONSTRAINTS("password-constraints", "비밀번호 제약조건");
 

--- a/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocs.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocs.java
@@ -15,4 +15,5 @@ public class EnumDocs {
     //문서화 대상 Enum 타입명
     Map<String, String> categoryType;
     Map<String, String> statsCriteria;
+    Map<String, String> financeStatus;
 }

--- a/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsController.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsController.java
@@ -3,6 +3,7 @@ package com.wanted.safewallet.docs.common.enums;
 import static java.util.stream.Collectors.toMap;
 
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
 import com.wanted.safewallet.global.enums.EnumType;
 import java.util.Arrays;
@@ -19,9 +20,11 @@ public class EnumDocsController {
     public EnumDocs getEnums() {
         Map<String, String> categoryType = getEnumMap(CategoryType.values());
         Map<String, String> statsCriteria = getEnumMap(StatsCriteria.values());
+        Map<String, String> financeStatus = getEnumMap(FinanceStatus.values());
         return EnumDocs.builder()
             .categoryType(categoryType)
             .statsCriteria(statsCriteria)
+            .financeStatus(financeStatus)
             .build();
     }
 

--- a/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
@@ -47,18 +47,18 @@ class EnumDocsControllerTest extends AbstractRestDocsTest {
                 enumFieldsSnippet(enumDocs.getFinanceStatus(), FinanceStatus.class.getSimpleName())));
     }
 
-    private static EnumDocs getData(MvcResult mvcResult) throws IOException {
+    private EnumDocs getData(MvcResult mvcResult) throws IOException {
         String content = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
         return objectMapper.readValue(content, EnumDocs.class);
     }
 
-    private static EnumFieldsSnippet enumFieldsSnippet(Map<String, String> enumValues, String enumTypeName) {
+    private EnumFieldsSnippet enumFieldsSnippet(Map<String, String> enumValues, String enumTypeName) {
         return new EnumFieldsSnippet(convertFieldDescriptors(enumValues),
             attributes(key(ATTRIBUTE_KEY).value(enumTypeName)), true,
-            beneathPath(uncapitalize(enumTypeName)).withSubsectionId(uncapitalize(enumTypeName)));
+            beneathPath(uncapitalize(enumTypeName)).withSubsectionId(enumTypeName));
     }
 
-    private static List<FieldDescriptor> convertFieldDescriptors(Map<String, String> enumValues) {
+    private List<FieldDescriptor> convertFieldDescriptors(Map<String, String> enumValues) {
         return enumValues.entrySet().stream()
             .map(e -> fieldWithPath(e.getKey()).description(e.getValue()))
             .toList();

--- a/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.util.StringUtils.uncapitalize;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.safewallet.docs.common.AbstractRestDocsTest;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import java.io.IOException;
@@ -42,7 +43,8 @@ class EnumDocsControllerTest extends AbstractRestDocsTest {
         resultActions.andExpect(status().isOk())
             .andDo(restDocs.document(
                 enumFieldsSnippet(enumDocs.getCategoryType(), CategoryType.class.getSimpleName()),
-                enumFieldsSnippet(enumDocs.getStatsCriteria(), StatsCriteria.class.getSimpleName())));
+                enumFieldsSnippet(enumDocs.getStatsCriteria(), StatsCriteria.class.getSimpleName()),
+                enumFieldsSnippet(enumDocs.getFinanceStatus(), FinanceStatus.class.getSimpleName())));
     }
 
     private static EnumDocs getData(MvcResult mvcResult) throws IOException {

--- a/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultServiceTest.java
@@ -1,0 +1,94 @@
+package com.wanted.safewallet.domain.expenditure.business.service;
+
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.ETC;
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.FOOD;
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.TRAFFIC;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.EXCELLENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenditureConsultServiceTest {
+
+    @InjectMocks
+    ExpenditureConsultService expenditureConsultService;
+
+    @Spy
+    ExpenditureMapper expenditureMapper;
+
+    @Mock
+    BudgetService budgetService;
+
+    @Mock
+    ExpenditureRepository expenditureRepository;
+
+    @DisplayName("오늘 지출 추천 서비스 테스트 : 성공")
+    @Test
+    void consultTodayExpenditure() {
+        //given
+        String userId = "testUserId";
+        Map<Category, Long> budgetTotalAmountByCategory = Map.of(
+            Category.builder().id(1L).type(FOOD).build(), 300_000L,
+            Category.builder().id(2L).type(TRAFFIC).build(), 200_000L,
+            Category.builder().id(3L).type(ETC).build(), 100_000L);
+        Map<Category, Long> expenditureTotalAmountByCategory = Map.of(
+            Category.builder().id(1L).type(FOOD).build(), 30_000L,
+            Category.builder().id(2L).type(TRAFFIC).build(), 20_000L,
+            Category.builder().id(3L).type(ETC).build(), 10_000L);
+        given(budgetService.getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class)))
+            .willReturn(budgetTotalAmountByCategory);
+        given(expenditureRepository.findTotalAmountMapByUserAndExpenditureDateRange(
+            anyString(), any(LocalDate.class), any(LocalDate.class)))
+            .willReturn(expenditureTotalAmountByCategory);
+
+        //LocalDate 내 모든 static 메소드가 아닌 now 메소드만 mocking
+        try (MockedStatic<LocalDate> mockedStatic = mockStatic(LocalDate.class, Mockito.CALLS_REAL_METHODS)) {
+            LocalDate now = LocalDate.of(2023, 12, 7);
+            mockedStatic.when(LocalDate::now).thenReturn(now);
+
+            //when
+            TodayExpenditureConsultResponseDto responseDto = expenditureConsultService.consultTodayExpenditure(userId);
+
+            //then
+            then(budgetService).should(times(1))
+                .getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class));
+            then(expenditureRepository).should(times(1))
+                .findTotalAmountMapByUserAndExpenditureDateRange(anyString(), any(LocalDate.class), any(LocalDate.class));
+            assertThat(responseDto.getTodayTotalAmount()).isEqualTo(21600);
+            assertThat(responseDto.getTotalFinanceStatus()).isEqualTo(EXCELLENT);
+            assertThat(responseDto.getTodayExpenditureConsultOfCategoryList()).satisfiesExactly(
+                item1 -> assertThat(item1)
+                    .extracting("type", "todayTotalAmount", "financeStatus")
+                    .containsExactly(FOOD, 10800L, EXCELLENT),
+                item2 -> assertThat(item2)
+                    .extracting("type", "todayTotalAmount", "financeStatus")
+                    .containsExactly(TRAFFIC, 7200L, EXCELLENT),
+                item3 -> assertThat(item3)
+                    .extracting("type", "todayTotalAmount", "financeStatus")
+                    .containsExactly(ETC, 3600L, EXCELLENT));
+        }
+    }
+}

--- a/src/test/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureControllerTest.java
@@ -1,14 +1,23 @@
 package com.wanted.safewallet.domain.expenditure.web.controller;
 
+import static com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.DocsPopupInfo.CATEGORY_TYPE;
+import static com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.DocsPopupInfo.FINANCE_STATUS;
+import static com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.DocsPopupInfo.PAGING_RESPONSE;
+import static com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.DocsPopupInfo.STATS_CRITERIA;
+import static com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.generatePopupLink;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.CLOTHING;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.ETC;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.FOOD;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.LEISURE;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.RESIDENCE;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.TRAFFIC;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.BAD;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.EXCELLENT;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.GOOD;
 import static com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria.LAST_MONTH;
 import static com.wanted.safewallet.utils.JsonUtils.asJsonString;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -35,9 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.util.StringUtils.collectionToCommaDelimitedString;
 
 import com.wanted.safewallet.docs.common.AbstractRestDocsTest;
-import com.wanted.safewallet.docs.common.DocsPopupLinkGenerator;
-import com.wanted.safewallet.docs.common.DocsPopupLinkGenerator.DocsPopupInfo;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureConsultService;
 import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureService;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureCreateRequestDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureSearchCond;
@@ -50,6 +58,8 @@ import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSear
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSearchResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto.ConsumptionRateByCategoryResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto.TodayExpenditureConsultOfCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TotalAmountByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
 import com.wanted.safewallet.global.dto.response.PageResponse;
@@ -73,6 +83,9 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
     @MockBean
     ExpenditureService expenditureService;
 
+    @MockBean
+    ExpenditureConsultService expenditureConsultService;
+
     @Autowired
     MockMvc mockMvc;
 
@@ -95,8 +108,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("expenditureDate").description("지출 발생 년월일"),
                     fieldWithPath("amount").description("지출 금액"),
                     fieldWithPath("categoryId").description("카테고리 id"),
-                    fieldWithPath("type").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("note").description("지출 관련 메모")
                 )
             ));
@@ -175,8 +187,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("totalAmount").description("총 지출 합계"),
                     fieldWithPath("totalAmountListByCategory").description("카테고리 별 지출 합계 목록"),
                     fieldWithPath("totalAmountListByCategory[].categoryId").description("카테고리 id"),
-                    fieldWithPath("totalAmountListByCategory[].type")
-                        .description(DocsPopupLinkGenerator.generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("totalAmountListByCategory[].type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("totalAmountListByCategory[].totalAmount").description("카테고리 별 지출 합계"),
                     fieldWithPath("expenditureListByDate").description("날짜 별 지출 상세 목록"),
                     fieldWithPath("expenditureListByDate[].expenditureDate").description("지출 날짜"),
@@ -184,11 +195,9 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("expenditureListByDate[].expenditureList[].expenditureId").description("지출 id"),
                     fieldWithPath("expenditureListByDate[].expenditureList[].amount").description("지출 금액"),
                     fieldWithPath("expenditureListByDate[].expenditureList[].categoryId").description("카테고리 id"),
-                    fieldWithPath("expenditureListByDate[].expenditureList[].type")
-                        .description(DocsPopupLinkGenerator.generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("expenditureListByDate[].expenditureList[].type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("expenditureListByDate[].expenditureList[].note").description("지출 관련 메모"),
-                    subsectionWithPath("paging").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.PAGING_RESPONSE)))));
+                    subsectionWithPath("paging").description(generatePopupLink(PAGING_RESPONSE)))));
     }
 
     @DisplayName("지출 내역 목록 조회 시 합계 제외 컨트롤러 테스트 : 성공")
@@ -248,8 +257,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("totalAmount").description("총 지출 합계(excepts 파라미터에서 지정한 지출은 제외)"),
                     fieldWithPath("totalAmountListByCategory").description("카테고리 별 지출 합계 목록"),
                     fieldWithPath("totalAmountListByCategory[].categoryId").description("카테고리 id"),
-                    fieldWithPath("totalAmountListByCategory[].type")
-                        .description(DocsPopupLinkGenerator.generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("totalAmountListByCategory[].type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("totalAmountListByCategory[].totalAmount")
                         .description("카테고리 별 지출 합계(excepts 파라미터에서 지정한 지출은 제외)"))));
     }
@@ -316,8 +324,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("amount").description("지출 금액")
                         .attributes(key("constraints").value("0원 이상")),
                     fieldWithPath("categoryId").description("카테고리 id"),
-                    fieldWithPath("type").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("note").description("지출 관련 메모").optional()),
                 responseFields(
                     beneathPath("data").withSubsectionId("data"),
@@ -366,8 +373,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("amount").description("지출 금액")
                         .attributes(key("constraints").value("0원 이상")),
                     fieldWithPath("categoryId").description("카테고리 id"),
-                    fieldWithPath("type").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("note").description("지출 관련 메모").optional())));
         then(expenditureService).should(times(1)).updateExpenditure(
             anyString(), anyLong(), any(ExpenditureUpdateRequestDto.class));
@@ -437,8 +443,7 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
             .andExpect(status().isOk())
             .andDo(restDocs.document(
                 queryParameters(
-                    parameterWithName("criteria").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.STATS_CRITERIA))
+                    parameterWithName("criteria").description(generatePopupLink(STATS_CRITERIA))
                         .attributes(key("default").value(LAST_MONTH)).optional()),
                 responseFields(
                     beneathPath("data").withSubsectionId("data"),
@@ -449,10 +454,42 @@ class ExpenditureControllerTest extends AbstractRestDocsTest {
                     fieldWithPath("totalConsumptionRate").description("지난 년도, 달, 주 대비 전체 소비율(%)"),
                     fieldWithPath("consumptionRateListByCategory").description("카테고리 별 소비율 목록"),
                     fieldWithPath("consumptionRateListByCategory[].categoryId").description("카테고리 id"),
-                    fieldWithPath("consumptionRateListByCategory[].type").description(DocsPopupLinkGenerator
-                        .generatePopupLink(DocsPopupInfo.CATEGORY_TYPE)),
+                    fieldWithPath("consumptionRateListByCategory[].type").description(generatePopupLink(CATEGORY_TYPE)),
                     fieldWithPath("consumptionRateListByCategory[].consumptionRate")
                         .description("지난 년도, 달, 주 대비 해당 카테고리의 소비율(%)"))
+            ));
+    }
+
+    @DisplayName("오늘 지출 추천 컨트롤러 테스트 : 성공")
+    @Test
+    void consultTodayExpenditure() throws Exception {
+        //given
+        List<TodayExpenditureConsultOfCategoryResponseDto> todayExpenditureConsultOfCategoryList = List.of(
+            new TodayExpenditureConsultOfCategoryResponseDto(1L, FOOD, 10800L, EXCELLENT),
+            new TodayExpenditureConsultOfCategoryResponseDto(2L, TRAFFIC, 7200L, EXCELLENT),
+            new TodayExpenditureConsultOfCategoryResponseDto(3L, RESIDENCE, 300000L, GOOD),
+            new TodayExpenditureConsultOfCategoryResponseDto(4L, CLOTHING, 15000L, BAD),
+            new TodayExpenditureConsultOfCategoryResponseDto(5L, LEISURE, 10000L, GOOD),
+            new TodayExpenditureConsultOfCategoryResponseDto(6L, ETC, 3600L, EXCELLENT));
+        TodayExpenditureConsultResponseDto responseDto = new TodayExpenditureConsultResponseDto(
+            346600L, EXCELLENT, todayExpenditureConsultOfCategoryList);
+        given(expenditureConsultService.consultTodayExpenditure(anyString())).willReturn(responseDto);
+
+        //when, then
+        restDocsMockMvc.perform(get("/api/expenditures/consult")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.todayExpenditureConsultOfCategoryList", hasSize(6)))
+            .andDo(restDocs.document(
+                responseFields(
+                    beneathPath("data").withSubsectionId("data"),
+                    fieldWithPath("todayTotalAmount").description("오늘 지출 추천 총액"),
+                    fieldWithPath("totalFinanceStatus").description(generatePopupLink(FINANCE_STATUS)),
+                    fieldWithPath("todayExpenditureConsultOfCategoryList").description("카테고리 별 오늘 지출 추천 목록"),
+                    fieldWithPath("todayExpenditureConsultOfCategoryList[].categoryId").description("카테고리 id"),
+                    fieldWithPath("todayExpenditureConsultOfCategoryList[].type").description(generatePopupLink(CATEGORY_TYPE)),
+                    fieldWithPath("todayExpenditureConsultOfCategoryList[].todayTotalAmount").description("카테고리 별 오늘 지출 추천 금액"),
+                    fieldWithPath("todayExpenditureConsultOfCategoryList[].financeStatus").description(generatePopupLink(FINANCE_STATUS)))
             ));
     }
 }


### PR DESCRIPTION
## 🚀What's PR?

- 설정한 월별 예산을 만족하기 위해 오늘 지출 가능한 금액을 `총액`과 `카테고리 별 금액`으로 제공
- **고려사항 1.** 앞선 일자에서 과다 소비하였더라도 오늘 예산을 극히 줄이는 것이 아닌, 이후 일자에 부담을 분배 
- **고려사항 2.** 전체 예산을 초과했더라도 `0원` 또는 `음수`의 예산은 추천하지 않음, `최소 금액` 또는 `적정한 금액`을 추천 (예산이 0원인 경우에는 `0원` 추천)
- `절약하여 소비한 경우`, `예산에 맞게 소비한 경우`, `예산 초과 위험이 있는 경우`, `현재까지의 지출이 예산을 초과한 경우` 등 유저의 상황에 맞는 메세지를 같이 노출 ex. `EXCELLENT`, `GOOD`, `WARN`, `BAD`
- `15333원` 같은 값이라면 백원 단위 반올림으로 사용자 친화적으로 변환
- 특정 시간에 Discord webhook, 이메일, 카카오톡 등 알림 발송 (추후 구현 예정)

## ⚠️Concerns

- 월별 예산 설정 시 하루 적정 지출 금액을 계산하여 캐싱?
- 해당 월의 이전 지출 내역도 중요 → 이전에 덜 썼으면 현재 더 씀, 이전에 더 썼으면 현재 덜 씀
- 주거비, 예를 들어 월세는 매일 발생하는 지출이 아님, 근데 매일 추천?

**TODO**: 위 사항 고려하여 구현에 적용하기

<br/>

🎫**Jira Ticket Number**: [SW-4]

[SW-4]: https://jkde7721.atlassian.net/browse/SW-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ