### PR TITLE
오늘 지출 안내 API

### DIFF
--- a/src/docs/asciidoc/expenditure-api.adoc
+++ b/src/docs/asciidoc/expenditure-api.adoc
@@ -65,5 +65,19 @@ operation::expenditure-controller-test/produce-expenditure-stats[snippets="http-
 - `절약하여 소비한 경우`, `예산에 맞게 소비한 경우`, `예산 초과 위험이 있는 경우`, `현재까지의 지출이 예산을 초과한 경우` 등 유저의 상황에 맞는 메세지를 같이 노출 ex. `EXCELLENT`, `GOOD`, `WARN`, `BAD`
 - `15333원` 같은 값이라면 백원 단위 반올림으로 사용자 친화적으로 변환
 - 특정 시간에 Discord webhook, 이메일, 카카오톡 등 알림 발송 (추후 구현 예정)
+- 유저가 직접 요청하는 API가 아닌 스케줄러 등 서버 내부적으로 요청하는 API
 
 operation::expenditure-controller-test/consult-today-expenditure[snippets="response-body,response-fields-data"]
+
+=== 오늘 지출 안내 API
+==== `GET /api/expenditures/daily-stats`
+
+- 오늘 지출한 내용을 `총액` 과 `카테고리 별 금액` 으로 조회
+- 월별 설정한 예산 기준 `카테고리 별 통계` 제공
+- 카테고리 별 오늘 `적정 금액`: 오늘 사용했으면 적절했을 금액
+- 카테고리 별 오늘 `지출 금액`: 오늘 실제로 사용한 금액
+- `소비율`: 카테고리 별 적정 지출 금액 대비 실제 지출 금액의 비율을 의미 (% 단위)
+- 특정 시간에 Discord webhook, 이메일, 카카오톡 등 알림 발송 (추후 구현 예정)
+- 유저가 직접 요청하는 API가 아닌 스케줄러 등 서버 내부적으로 요청하는 API
+
+operation::expenditure-controller-test/produce-today-expenditure-daily-stats[snippets="response-body,response-fields-data"]

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/mapper/ExpenditureMapper.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/mapper/ExpenditureMapper.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureConsultVo;
+import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureDailyStatsVo;
 import com.wanted.safewallet.domain.expenditure.persistence.dto.response.StatsByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureCreateRequestDto;
@@ -18,6 +19,8 @@ import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStat
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto.ConsumptionRateByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto.TodayExpenditureConsultOfCategoryResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto.TodayExpenditureDailyStatsOfCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TotalAmountByCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
 import com.wanted.safewallet.domain.user.persistence.entity.User;
@@ -135,5 +138,18 @@ public class ExpenditureMapper {
                     todayExpenditureConsultByCategory.get(category).financeStatus()))
                 .toList();
         return new TodayExpenditureConsultResponseDto(todayTotalAmount, totalFinanceStatus, todayExpenditureConsultOfCategoryList);
+    }
+
+    public TodayExpenditureDailyStatsResponseDto toDto(Long todayTotalAmount,
+        Map<Category, TodayExpenditureDailyStatsVo> todayExpenditureDailyStatsByCategory) {
+        List<TodayExpenditureDailyStatsOfCategoryResponseDto> todayExpenditureDailyStatsOfCategoryList =
+            todayExpenditureDailyStatsByCategory.keySet().stream()
+                .sorted(Comparator.comparing(Category::getId))
+                .map(category -> new TodayExpenditureDailyStatsOfCategoryResponseDto(category.getId(), category.getType(),
+                    todayExpenditureDailyStatsByCategory.get(category).consultedTotalAmount(),
+                    todayExpenditureDailyStatsByCategory.get(category).todayTotalAmount(),
+                    todayExpenditureDailyStatsByCategory.get(category).consumptionRate()))
+                .toList();
+        return new TodayExpenditureDailyStatsResponseDto(todayTotalAmount, todayExpenditureDailyStatsOfCategoryList);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
@@ -30,6 +30,7 @@ public class ExpenditureDailyStatsService {
         YearMonth currentYearMonth = YearMonth.of(expenditureDate.getYear(), expenditureDate.getMonth());
         int daysOfCurrentMonth = currentYearMonth.lengthOfMonth();
         Map<Category, Long> budgetTotalAmountByCategory = budgetService.getBudgetTotalAmountByCategory(userId, currentYearMonth);
+        //TODO: 아래 값 정확하지 않음 (현재까지의 지출 고려X)
         Map<Category, Long> budgetAmountPerDayByCategory = getBudgetAmountPerDayByCategory(budgetTotalAmountByCategory, daysOfCurrentMonth);
         Map<Category, Long> todayExpenditureTotalAmountByCategory = expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(userId, expenditureDate);
 

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
@@ -1,0 +1,71 @@
+package com.wanted.safewallet.domain.expenditure.business.service;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
+import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureDailyStatsVo;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ExpenditureDailyStatsService {
+
+    private final ExpenditureMapper expenditureMapper;
+    private final BudgetService budgetService;
+    private final ExpenditureRepository expenditureRepository;
+
+    public TodayExpenditureDailyStatsResponseDto produceTodayExpenditureDailyStats(String userId) {
+        LocalDate expenditureDate = LocalDate.now();
+        YearMonth currentYearMonth = YearMonth.of(expenditureDate.getYear(), expenditureDate.getMonth());
+        int daysOfCurrentMonth = currentYearMonth.lengthOfMonth();
+        Map<Category, Long> budgetTotalAmountByCategory = budgetService.getBudgetTotalAmountByCategory(userId, currentYearMonth);
+        Map<Category, Long> budgetAmountPerDayByCategory = getBudgetAmountPerDayByCategory(budgetTotalAmountByCategory, daysOfCurrentMonth);
+        Map<Category, Long> todayExpenditureTotalAmountByCategory = expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(userId, expenditureDate);
+
+        Long todayTotalAmount = calculateTodayTotalAmount(todayExpenditureTotalAmountByCategory);
+        Map<Category, TodayExpenditureDailyStatsVo> todayExpenditureDailyStatsByCategory =
+            getTodayExpenditureDailyStatsByCategory(budgetAmountPerDayByCategory, todayExpenditureTotalAmountByCategory);
+        return expenditureMapper.toDto(todayTotalAmount, todayExpenditureDailyStatsByCategory);
+    }
+
+    //추후 캐시 적용으로 제거할 메소드
+    private Map<Category, Long> getBudgetAmountPerDayByCategory(Map<Category, Long> budgetTotalAmountByCategory, int daysOfCurrentMonth) {
+        return budgetTotalAmountByCategory.keySet().stream().collect(toMap(identity(), category ->
+            calculateAmountPerDay(budgetTotalAmountByCategory.get(category), daysOfCurrentMonth)));
+    }
+
+    //추후 캐시 적용으로 제거할 메소드
+    private Long calculateAmountPerDay(Long totalAmount, int days) {
+        return (long) ((double) totalAmount / days / 100) * 100; //100원 단위로 환산
+    }
+
+    private Long calculateTodayTotalAmount(Map<Category, Long> todayExpenditureTotalAmountByCategory) {
+        return todayExpenditureTotalAmountByCategory.values().stream().mapToLong(Long::longValue).sum();
+    }
+
+    private Map<Category, TodayExpenditureDailyStatsVo> getTodayExpenditureDailyStatsByCategory(
+        Map<Category, Long> budgetAmountPerDayByCategory, Map<Category, Long> todayExpenditureTotalAmountByCategory) {
+        return budgetAmountPerDayByCategory.keySet().stream()
+            .collect(toMap(identity(), category -> new TodayExpenditureDailyStatsVo(
+                budgetAmountPerDayByCategory.get(category), todayExpenditureTotalAmountByCategory.get(category),
+                calculateConsumptionRate(budgetAmountPerDayByCategory.get(category),
+                    todayExpenditureTotalAmountByCategory.get(category)))));
+    }
+
+    //TODO: ExpenditureService 내 메소드와 중복되므로 제거
+    private Long calculateConsumptionRate(Long budgetAmount, Long expenditureAmount) {
+        if (budgetAmount == 0) budgetAmount = 1L;
+        return Math.round((double) expenditureAmount / budgetAmount * 100); //% 단위로 변환하기 위해 곱하기 100
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/TodayExpenditureDailyStatsVo.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/TodayExpenditureDailyStatsVo.java
@@ -1,0 +1,6 @@
+package com.wanted.safewallet.domain.expenditure.business.vo;
+
+public record TodayExpenditureDailyStatsVo(Long consultedTotalAmount,
+                                           Long todayTotalAmount,
+                                           Long consumptionRate) {
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryCustom.java
@@ -22,4 +22,6 @@ public interface ExpenditureRepositoryCustom {
     List<TotalAmountByCategoryResponseDto> getTotalAmountByCategoryList(String userId, LocalDate startDate, LocalDate endDate);
 
     Map<Category, Long> findTotalAmountMapByUserAndExpenditureDateRange(String userId, LocalDate startDate, LocalDate endDate);
+
+    Map<Category, Long> findTotalAmountMapByUserAndExpenditureDate(String userId, LocalDate expenditureDate);
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/controller/ExpenditureController.java
@@ -1,6 +1,7 @@
 package com.wanted.safewallet.domain.expenditure.web.controller;
 
 import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureConsultService;
+import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureDailyStatsService;
 import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureService;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureCreateRequestDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.request.ExpenditureSearchCond;
@@ -11,6 +12,7 @@ import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSear
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureSearchExceptsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.ExpenditureStatsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
 import com.wanted.safewallet.global.auth.annotation.CurrentUserId;
 import com.wanted.safewallet.global.dto.response.aop.CommonResponseContent;
@@ -37,6 +39,7 @@ public class ExpenditureController {
 
     private final ExpenditureService expenditureService;
     private final ExpenditureConsultService expenditureConsultService;
+    private final ExpenditureDailyStatsService expenditureDailyStatsService;
 
     @GetMapping("/{expenditureId}")
     public ExpenditureDetailsResponseDto getExpenditureDetails(@PathVariable Long expenditureId,
@@ -84,5 +87,10 @@ public class ExpenditureController {
     @GetMapping("/consult")
     public TodayExpenditureConsultResponseDto consultTodayExpenditure(@CurrentUserId String userId) {
         return expenditureConsultService.consultTodayExpenditure(userId);
+    }
+
+    @GetMapping("/daily-stats")
+    public TodayExpenditureDailyStatsResponseDto produceTodayExpenditureDailyStats(@CurrentUserId String userId) {
+        return expenditureDailyStatsService.produceTodayExpenditureDailyStats(userId);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureDailyStatsResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureDailyStatsResponseDto.java
@@ -1,0 +1,30 @@
+package com.wanted.safewallet.domain.expenditure.web.dto.response;
+
+import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TodayExpenditureDailyStatsResponseDto {
+
+    private Long todayTotalAmount;
+
+    private List<TodayExpenditureDailyStatsOfCategoryResponseDto> todayExpenditureDailyStatsOfCategoryList;
+
+    @Getter
+    @AllArgsConstructor
+    public static class TodayExpenditureDailyStatsOfCategoryResponseDto {
+
+        private Long categoryId;
+
+        private CategoryType type;
+
+        private Long consultedTotalAmount;
+
+        private Long todayTotalAmount;
+
+        private Long consumptionRate;
+    }
+}

--- a/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsServiceTest.java
@@ -1,0 +1,88 @@
+package com.wanted.safewallet.domain.expenditure.business.service;
+
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.ETC;
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.FOOD;
+import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.TRAFFIC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.category.persistence.entity.Category;
+import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenditureDailyStatsServiceTest {
+
+    @InjectMocks
+    ExpenditureDailyStatsService expenditureDailyStatsService;
+
+    @Spy
+    ExpenditureMapper expenditureMapper;
+
+    @Mock
+    BudgetService budgetService;
+
+    @Mock
+    ExpenditureRepository expenditureRepository;
+
+    @DisplayName("오늘 지출 안내 서비스 테스트 : 성공")
+    @Test
+    void produceTodayExpenditureDailyStats() {
+        //given
+        String userId = "testUserId";
+        Map<Category, Long> budgetTotalAmountByCategory = Map.of(
+            Category.builder().id(1L).type(FOOD).build(), 300_000L,
+            Category.builder().id(2L).type(TRAFFIC).build(), 200_000L,
+            Category.builder().id(3L).type(ETC).build(), 100_000L);
+        Map<Category, Long> todayExpenditureTotalAmountByCategory = Map.of(
+            Category.builder().id(1L).type(FOOD).build(), 9600L,
+            Category.builder().id(2L).type(TRAFFIC).build(), 3200L,
+            Category.builder().id(3L).type(ETC).build(), 4800L);
+        given(budgetService.getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class)))
+            .willReturn(budgetTotalAmountByCategory);
+        given(expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(anyString(), any(LocalDate.class)))
+            .willReturn(todayExpenditureTotalAmountByCategory);
+
+        try (MockedStatic<LocalDate> mockedStatic = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            LocalDate now = LocalDate.of(2023, 12, 7);
+            mockedStatic.when(LocalDate::now).thenReturn(now);
+
+            //when
+            TodayExpenditureDailyStatsResponseDto responseDto = expenditureDailyStatsService
+                .produceTodayExpenditureDailyStats(userId);
+
+            //then
+            then(budgetService).should(times(1))
+                .getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class));
+            then(expenditureRepository).should(times(1))
+                .findTotalAmountMapByUserAndExpenditureDate(anyString(), any(LocalDate.class));
+            assertThat(responseDto.getTodayTotalAmount()).isEqualTo(17600L);
+            assertThat(responseDto.getTodayExpenditureDailyStatsOfCategoryList()).satisfiesExactly(
+                item1 -> assertThat(item1).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                    .containsExactly(FOOD, 9600L, 9600L, 100L),
+                item2 -> assertThat(item2).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                    .containsExactly(TRAFFIC, 6400L, 3200L, 50L),
+                item3 -> assertThat(item3).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                    .containsExactly(ETC, 3200L, 4800L, 150L));
+        }
+    }
+}


### PR DESCRIPTION
## 🚀What's PR?

- 오늘 지출한 내용을 `총액`과 `카테고리 별 금액`으로 조회 
- 월별 설정한 예산 기준 `카테고리 별 통계` 제공 
  - 카테고리 별 오늘 `적정 금액`: 오늘 사용했으면 적절했을 금액 → 오늘 지출 추천 시 캐싱
  - 카테고리 별 오늘 `지출 금액`: 오늘 실제로 사용한 금액 
  - `소비율`: 카테고리 별 적정 지출 추천 금액 대비 실제 지출 금액의 비율을 의미 (% 단위)
- 특정 시간에 Discord webhook, 이메일, 카카오톡 등 알림 발송
- 유저가 직접 요청하는 API가 아닌 스케줄러 등 서버 내부적으로 요청하는 API

## ⚠️Concerns

TODO: 오늘 지출 추천 시 추천 금액 캐싱 구현하여 적용하기

<br/>

🎫**Jira Ticket Number**: [SW-20]

[SW-20]: https://jkde7721.atlassian.net/browse/SW-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ