### PR TITLE
오늘 지출 추천, 안내 API 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	//Redis 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	//Spring Rest Docs 의존성
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +30,9 @@ public class ExpenditureConsultService {
     private final ExpenditureMapper expenditureMapper;
     private final BudgetService budgetService;
     private final ExpenditureRepository expenditureRepository;
+    private static final String CACHE_NAME = "today-expenditure-consult";
 
+    @Cacheable(cacheNames = CACHE_NAME, key = "#userId")
     public TodayExpenditureConsultResponseDto consultTodayExpenditure(String userId) {
         LocalDate expenditureEndDate = LocalDate.now();
         YearMonth currentYearMonth = YearMonth.of(expenditureEndDate.getYear(), expenditureEndDate.getMonth());

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureConsultService.java
@@ -30,7 +30,7 @@ public class ExpenditureConsultService {
     private final ExpenditureMapper expenditureMapper;
     private final BudgetService budgetService;
     private final ExpenditureRepository expenditureRepository;
-    private static final String CACHE_NAME = "today-expenditure-consult";
+    public static final String CACHE_NAME = "today-expenditure-consult";
 
     @Cacheable(cacheNames = CACHE_NAME, key = "#userId")
     public TodayExpenditureConsultResponseDto consultTodayExpenditure(String userId) {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsService.java
@@ -3,14 +3,14 @@ package com.wanted.safewallet.domain.expenditure.business.service;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
-import com.wanted.safewallet.domain.budget.business.service.BudgetService;
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
 import com.wanted.safewallet.domain.expenditure.business.vo.TodayExpenditureDailyStatsVo;
 import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto.TodayExpenditureConsultOfCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,17 +22,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExpenditureDailyStatsService {
 
     private final ExpenditureMapper expenditureMapper;
-    private final BudgetService budgetService;
+    private final ExpenditureConsultService expenditureConsultService;
     private final ExpenditureRepository expenditureRepository;
 
     public TodayExpenditureDailyStatsResponseDto produceTodayExpenditureDailyStats(String userId) {
-        LocalDate expenditureDate = LocalDate.now();
-        YearMonth currentYearMonth = YearMonth.of(expenditureDate.getYear(), expenditureDate.getMonth());
-        int daysOfCurrentMonth = currentYearMonth.lengthOfMonth();
-        Map<Category, Long> budgetTotalAmountByCategory = budgetService.getBudgetTotalAmountByCategory(userId, currentYearMonth);
-        //TODO: 아래 값 정확하지 않음 (현재까지의 지출 고려X)
-        Map<Category, Long> budgetAmountPerDayByCategory = getBudgetAmountPerDayByCategory(budgetTotalAmountByCategory, daysOfCurrentMonth);
-        Map<Category, Long> todayExpenditureTotalAmountByCategory = expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(userId, expenditureDate);
+        LocalDate now = LocalDate.now();
+        TodayExpenditureConsultResponseDto todayExpenditureConsult = expenditureConsultService.consultTodayExpenditure(userId);
+        Map<Category, Long> budgetAmountPerDayByCategory = convertToBudgetAmountPerDayByCategory(todayExpenditureConsult);
+        Map<Category, Long> todayExpenditureTotalAmountByCategory = expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(userId, now);
 
         Long todayTotalAmount = calculateTodayTotalAmount(todayExpenditureTotalAmountByCategory);
         Map<Category, TodayExpenditureDailyStatsVo> todayExpenditureDailyStatsByCategory =
@@ -40,15 +37,10 @@ public class ExpenditureDailyStatsService {
         return expenditureMapper.toDto(todayTotalAmount, todayExpenditureDailyStatsByCategory);
     }
 
-    //추후 캐시 적용으로 제거할 메소드
-    private Map<Category, Long> getBudgetAmountPerDayByCategory(Map<Category, Long> budgetTotalAmountByCategory, int daysOfCurrentMonth) {
-        return budgetTotalAmountByCategory.keySet().stream().collect(toMap(identity(), category ->
-            calculateAmountPerDay(budgetTotalAmountByCategory.get(category), daysOfCurrentMonth)));
-    }
-
-    //추후 캐시 적용으로 제거할 메소드
-    private Long calculateAmountPerDay(Long totalAmount, int days) {
-        return (long) ((double) totalAmount / days / 100) * 100; //100원 단위로 환산
+    private Map<Category, Long> convertToBudgetAmountPerDayByCategory(TodayExpenditureConsultResponseDto todayExpenditureConsult) {
+        return todayExpenditureConsult.getTodayExpenditureConsultOfCategoryList().stream()
+            .collect(toMap(consult -> Category.builder().id(consult.getCategoryId()).type(consult.getType()).build(),
+                TodayExpenditureConsultOfCategoryResponseDto::getTodayTotalAmount));
     }
 
     private Long calculateTodayTotalAmount(Map<Category, Long> todayExpenditureTotalAmountByCategory) {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/ExpenditureDateUpdateVo.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/vo/ExpenditureDateUpdateVo.java
@@ -1,0 +1,8 @@
+package com.wanted.safewallet.domain.expenditure.business.vo;
+
+import java.time.LocalDate;
+
+public record ExpenditureDateUpdateVo(LocalDate originalExpenditureDate,
+                                      LocalDate updatedExpenditureDate) {
+
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureConsultResponseDto.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/web/dto/response/TodayExpenditureConsultResponseDto.java
@@ -5,9 +5,11 @@ import com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class TodayExpenditureConsultResponseDto {
 
     private Long todayTotalAmount;
@@ -18,6 +20,7 @@ public class TodayExpenditureConsultResponseDto {
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class TodayExpenditureConsultOfCategoryResponseDto {
 
         private Long categoryId;

--- a/src/main/java/com/wanted/safewallet/global/config/CacheConfig.java
+++ b/src/main/java/com/wanted/safewallet/global/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.wanted.safewallet.global.config;
+
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair.fromSerializer;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(60))
+            .disableCachingNullValues()
+            .serializeKeysWith(fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(fromSerializer(new GenericJackson2JsonRedisSerializer()));
+    }
+}

--- a/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureDailyStatsServiceTest.java
@@ -3,29 +3,29 @@ package com.wanted.safewallet.domain.expenditure.business.service;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.ETC;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.FOOD;
 import static com.wanted.safewallet.domain.category.persistence.entity.CategoryType.TRAFFIC;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.EXCELLENT;
+import static com.wanted.safewallet.domain.expenditure.web.enums.FinanceStatus.GOOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
-import com.wanted.safewallet.domain.budget.business.service.BudgetService;
 import com.wanted.safewallet.domain.category.persistence.entity.Category;
 import com.wanted.safewallet.domain.expenditure.business.mapper.ExpenditureMapper;
 import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto;
+import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureConsultResponseDto.TodayExpenditureConsultOfCategoryResponseDto;
 import com.wanted.safewallet.domain.expenditure.web.dto.response.TodayExpenditureDailyStatsResponseDto;
 import java.time.LocalDate;
-import java.time.YearMonth;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -39,7 +39,7 @@ class ExpenditureDailyStatsServiceTest {
     ExpenditureMapper expenditureMapper;
 
     @Mock
-    BudgetService budgetService;
+    ExpenditureConsultService expenditureConsultService;
 
     @Mock
     ExpenditureRepository expenditureRepository;
@@ -49,40 +49,36 @@ class ExpenditureDailyStatsServiceTest {
     void produceTodayExpenditureDailyStats() {
         //given
         String userId = "testUserId";
-        Map<Category, Long> budgetTotalAmountByCategory = Map.of(
-            Category.builder().id(1L).type(FOOD).build(), 300_000L,
-            Category.builder().id(2L).type(TRAFFIC).build(), 200_000L,
-            Category.builder().id(3L).type(ETC).build(), 100_000L);
+        List<TodayExpenditureConsultOfCategoryResponseDto> todayExpenditureConsultOfCategoryList = List.of(
+            new TodayExpenditureConsultOfCategoryResponseDto(1L, FOOD, 9600L, GOOD),
+            new TodayExpenditureConsultOfCategoryResponseDto(2L, TRAFFIC, 6400L, EXCELLENT),
+            new TodayExpenditureConsultOfCategoryResponseDto(3L, ETC, 3200L, GOOD));
+        TodayExpenditureConsultResponseDto todayExpenditureConsult = new TodayExpenditureConsultResponseDto(
+            19200L, GOOD, todayExpenditureConsultOfCategoryList);
         Map<Category, Long> todayExpenditureTotalAmountByCategory = Map.of(
             Category.builder().id(1L).type(FOOD).build(), 9600L,
             Category.builder().id(2L).type(TRAFFIC).build(), 3200L,
             Category.builder().id(3L).type(ETC).build(), 4800L);
-        given(budgetService.getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class)))
-            .willReturn(budgetTotalAmountByCategory);
+        given(expenditureConsultService.consultTodayExpenditure(anyString())).willReturn(todayExpenditureConsult);
         given(expenditureRepository.findTotalAmountMapByUserAndExpenditureDate(anyString(), any(LocalDate.class)))
             .willReturn(todayExpenditureTotalAmountByCategory);
 
-        try (MockedStatic<LocalDate> mockedStatic = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
-            LocalDate now = LocalDate.of(2023, 12, 7);
-            mockedStatic.when(LocalDate::now).thenReturn(now);
+        //when
+        TodayExpenditureDailyStatsResponseDto responseDto = expenditureDailyStatsService
+            .produceTodayExpenditureDailyStats(userId);
 
-            //when
-            TodayExpenditureDailyStatsResponseDto responseDto = expenditureDailyStatsService
-                .produceTodayExpenditureDailyStats(userId);
-
-            //then
-            then(budgetService).should(times(1))
-                .getBudgetTotalAmountByCategory(anyString(), any(YearMonth.class));
-            then(expenditureRepository).should(times(1))
-                .findTotalAmountMapByUserAndExpenditureDate(anyString(), any(LocalDate.class));
-            assertThat(responseDto.getTodayTotalAmount()).isEqualTo(17600L);
-            assertThat(responseDto.getTodayExpenditureDailyStatsOfCategoryList()).satisfiesExactly(
-                item1 -> assertThat(item1).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
-                    .containsExactly(FOOD, 9600L, 9600L, 100L),
-                item2 -> assertThat(item2).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
-                    .containsExactly(TRAFFIC, 6400L, 3200L, 50L),
-                item3 -> assertThat(item3).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
-                    .containsExactly(ETC, 3200L, 4800L, 150L));
-        }
+        //then
+        then(expenditureConsultService).should(times(1))
+            .consultTodayExpenditure(anyString());
+        then(expenditureRepository).should(times(1))
+            .findTotalAmountMapByUserAndExpenditureDate(anyString(), any(LocalDate.class));
+        assertThat(responseDto.getTodayTotalAmount()).isEqualTo(17600L);
+        assertThat(responseDto.getTodayExpenditureDailyStatsOfCategoryList()).satisfiesExactly(
+            item1 -> assertThat(item1).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                .containsExactly(FOOD, 9600L, 9600L, 100L),
+            item2 -> assertThat(item2).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                .containsExactly(TRAFFIC, 6400L, 3200L, 50L),
+            item3 -> assertThat(item3).extracting("type", "consultedTotalAmount", "todayTotalAmount", "consumptionRate")
+                .containsExactly(ETC, 3200L, 4800L, 150L));
     }
 }


### PR DESCRIPTION
## 🚀What's PR?

- 오늘 지출 추천 시 계산한 데이터 캐싱
- 이후 오늘 지출 안내에서 해당 캐싱한 데이터 조회하여 사용 ex. 오늘 사용했으면 적정한 금액, 적정 금액 대비 소비율

## ⚠️Concerns

- 오늘 적정 지출 금액 계산하기 위해 여러번 DB 데이터 조회 발생 + 어플리케이션 단에서 연산 수행 → 연산 비용 아끼고자 캐싱
- 만약 캐싱 후 새로운 지출 내역이 추가되거나 기존 지출 내역이 삭제 또는 변경된다면 캐시에서 해당 데이터 삭제
  - 현재 년월이면서 오늘 날짜 이전의 지출에 대해서만 `@CacheEvict` 적용
  - 만약 해당 날짜가 아니면 기존 캐시 데이터 삭제하지 않음

<br/>

🎫**Jira Ticket Number**: [SW-24]

[SW-24]: https://jkde7721.atlassian.net/browse/SW-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ