### PR TITLE
유저 탈퇴 API

### DIFF
--- a/src/docs/asciidoc/expenditure-api.adoc
+++ b/src/docs/asciidoc/expenditure-api.adoc
@@ -43,7 +43,7 @@ operation::expenditure-controller-test/update-expenditure[snippets="request-body
 ==== `DELETE /api/expenditures/{expenditureId}`
 
 - `지출` 을 생성한 유저만 권한
-- **Soft Delete** 수행
+- `지출 이미지 목록` 또한 모두 삭제
 
 operation::expenditure-controller-test/delete-expenditure[snippets="response-body"]
 

--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -11,3 +11,12 @@ operation::user-controller-test/check-for-username[snippets="http-request,respon
 === 사용자 회원가입 API
 ==== `POST /api/users`
 operation::user-controller-test/join-user[snippets="request-body,request-fields,response-body"]
+
+=== 사용자 탈퇴 API
+==== `DELETE /api/users`
+
+- 바로 탈퇴 처리하는 것이 아닌 계정 비활성화
+- 사용자 계정 비활성화 후 3개월 이내에 재로그인하지 않으면 탈퇴 처리 (사용자 관련 데이터 모두 삭제)
+- 3개월 이내에 재로그인 시 비활성화된 계정 복구
+
+operation::user-controller-test/deactivate-user[snippets="response-body"]

--- a/src/main/java/com/wanted/safewallet/SafeWalletApplication.java
+++ b/src/main/java/com/wanted/safewallet/SafeWalletApplication.java
@@ -3,7 +3,9 @@ package com.wanted.safewallet;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class SafeWalletApplication {

--- a/src/main/java/com/wanted/safewallet/domain/auth/business/service/CustomUserDetailsService.java
+++ b/src/main/java/com/wanted/safewallet/domain/auth/business/service/CustomUserDetailsService.java
@@ -1,8 +1,8 @@
 package com.wanted.safewallet.domain.auth.business.service;
 
 import com.wanted.safewallet.domain.auth.business.dto.CustomUserDetails;
+import com.wanted.safewallet.domain.user.business.service.UserService;
 import com.wanted.safewallet.domain.user.persistence.entity.User;
-import com.wanted.safewallet.domain.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -13,12 +13,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new UsernameNotFoundException("잘못된 계정명입니다."));
+        //활성화 계정 조회 -> 비활성화 계정 조회 -> 예외 발생
+        User user = userService.getActiveUserByUsername(username)
+            .orElseGet(() -> userService.getRestoredUserByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("잘못된 계정명입니다.")));
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/business/service/BudgetService.java
@@ -56,6 +56,11 @@ public class BudgetService {
         return consultBudgetAmount(totalAmountForConsult, prevBudgetAmountByCategory);
     }
 
+    @Transactional
+    public void deleteByUserIds(List<String> userIds) {
+        budgetRepository.deleteAllByUserIn(userIds);
+    }
+
     public void checkForDuplicatedBudget(String userId, YearMonth budgetYearMonth, List<Long> categoryIds) {
         if (budgetRepository.existsByUserAndBudgetYearMonthAndCategories(userId, budgetYearMonth, categoryIds)) {
             throw new BusinessException(ALREADY_EXISTS_BUDGET);

--- a/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/budget/persistence/repository/BudgetRepository.java
@@ -2,8 +2,10 @@ package com.wanted.safewallet.domain.budget.persistence.repository;
 
 import com.wanted.safewallet.domain.budget.persistence.entity.Budget;
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +17,8 @@ public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRep
 
     @Query("SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END FROM Budget b WHERE b.user.id = :userId")
     boolean existsByUser(@Param("userId") String userId);
+
+    @Modifying
+    @Query("delete from Budget b where b.user.id in :userIds")
+    void deleteAllByUserIn(@Param(("userIds")) List<String> userIds);
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureService.java
@@ -13,10 +13,12 @@ import com.wanted.safewallet.domain.expenditure.business.dto.ExpenditureStatsDat
 import com.wanted.safewallet.domain.expenditure.business.dto.ExpenditureStatsDto;
 import com.wanted.safewallet.domain.expenditure.business.dto.ExpenditureUpdateDto;
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureImageRepository;
 import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
 import com.wanted.safewallet.global.exception.BusinessException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExpenditureService {
 
     private final ExpenditureRepository expenditureRepository;
+    private final ExpenditureImageRepository expenditureImageRepository;
 
     public ExpenditureSearchDto searchExpenditure(String userId, ExpenditureSearchCond searchCond,
         Pageable pageable) {
@@ -78,6 +81,13 @@ public class ExpenditureService {
         return ExpenditureStatsDto.builder()
             .totalConsumptionRate(totalConsumptionRate)
             .consumptionRateByCategory(consumptionRateByCategory).build();
+    }
+
+    @Transactional
+    public void deleteByUserIds(List<String> userIds) {
+        List<Long> expenditureIds = expenditureRepository.findIdsByUser(userIds);
+        expenditureImageRepository.deleteAllByExpenditureIn(expenditureIds);
+        expenditureRepository.deleteAllByUserIn(userIds);
     }
 
     public Map<Category, Long> getExpenditureAmountByCategory(String userId, LocalDate date) {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureService.java
@@ -66,7 +66,8 @@ public class ExpenditureService {
 
     @Transactional
     public void deleteExpenditure(Expenditure expenditure) {
-        expenditure.softDelete();
+        expenditureImageRepository.deleteAllByExpenditure(expenditure.getId());
+        expenditureRepository.delete(expenditure);
     }
 
     public ExpenditureStatsDto produceExpenditureStats(String userId, ExpenditureStatsDateDto expenditureStatsDateDto) {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/entity/Expenditure.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/entity/Expenditure.java
@@ -21,7 +21,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -60,11 +59,6 @@ public class Expenditure extends BaseTime {
     private String note;
 
     @Builder.Default
-    @Column(nullable = false)
-    @ColumnDefault("0")
-    private Boolean deleted = Boolean.FALSE;
-
-    @Builder.Default
     @OneToMany(mappedBy = "expenditure",
         cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<ExpenditureImage> images = List.of();
@@ -85,9 +79,5 @@ public class Expenditure extends BaseTime {
         this.amount = amount;
         this.title = title;
         this.note = note;
-    }
-
-    public void softDelete() {
-        this.deleted = Boolean.TRUE;
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/entity/Expenditure.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/entity/Expenditure.java
@@ -59,8 +59,7 @@ public class Expenditure extends BaseTime {
     private String note;
 
     @Builder.Default
-    @OneToMany(mappedBy = "expenditure",
-        cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @OneToMany(mappedBy = "expenditure", cascade = CascadeType.PERSIST)
     private List<ExpenditureImage> images = List.of();
 
     public List<String> getImageUrls() {

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureImageRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureImageRepository.java
@@ -12,4 +12,8 @@ public interface ExpenditureImageRepository extends JpaRepository<ExpenditureIma
     @Modifying
     @Query("delete from ExpenditureImage ei where ei.expenditure.id in :expenditureIds")
     void deleteAllByExpenditureIn(@Param("expenditureIds") List<Long> expenditureIds);
+
+    @Modifying
+    @Query("delete from ExpenditureImage ei where ei.expenditure.id = :expenditureId")
+    void deleteAllByExpenditure(@Param("expenditureId") Long expenditureId);
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureImageRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureImageRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.safewallet.domain.expenditure.persistence.repository;
+
+import com.wanted.safewallet.domain.expenditure.persistence.entity.ExpenditureImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ExpenditureImageRepository extends JpaRepository<ExpenditureImage, Long> {
+
+    @Modifying
+    @Query("delete from ExpenditureImage ei where ei.expenditure.id in :expenditureIds")
+    void deleteAllByExpenditureIn(@Param("expenditureIds") List<Long> expenditureIds);
+}

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepository.java
@@ -2,16 +2,12 @@ package com.wanted.safewallet.domain.expenditure.persistence.repository;
 
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, ExpenditureRepositoryCustom {
-
-    @Query("select e from Expenditure e where e.id = :expenditureId and e.deleted = false")
-    Optional<Expenditure> findById(@Param("expenditureId") Long expenditureId);
 
     @Query("select e.id from Expenditure e where e.user.id in :userIds")
     List<Long> findIdsByUser(@Param("userIds") List<String> userIds);

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepository.java
@@ -1,8 +1,10 @@
 package com.wanted.safewallet.domain.expenditure.persistence.repository;
 
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,4 +12,11 @@ public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>,
 
     @Query("select e from Expenditure e where e.id = :expenditureId and e.deleted = false")
     Optional<Expenditure> findById(@Param("expenditureId") Long expenditureId);
+
+    @Query("select e.id from Expenditure e where e.user.id in :userIds")
+    List<Long> findIdsByUser(@Param("userIds") List<String> userIds);
+
+    @Modifying
+    @Query("delete from Expenditure e where e.user.id in :userIds")
+    void deleteAllByUserIn(@Param("userIds") List<String> userIds);
 }

--- a/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryImpl.java
+++ b/src/main/java/com/wanted/safewallet/domain/expenditure/persistence/repository/ExpenditureRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ExpenditureRepositoryImpl implements ExpenditureRepositoryCustom {
         return Optional.ofNullable(queryFactory.selectFrom(expenditure)
             .join(expenditure.category).fetchJoin()
             .leftJoin(expenditure.images).fetchJoin()
-            .where(expenditure.id.eq(expenditureId), notDeleted())
+            .where(expenditure.id.eq(expenditureId))
             .fetchOne());
     }
 
@@ -83,21 +83,16 @@ public class ExpenditureRepositoryImpl implements ExpenditureRepositoryCustom {
                     category, expenditure.amount.coalesce(0L).sum()))
                 .from(expenditure)
                 .rightJoin(expenditure.category, category)
-                .on(userIdEq(userId), expenditureDateBetween(startInclusive, endExclusive), notDeleted())
+                .on(userIdEq(userId), expenditureDateBetween(startInclusive, endExclusive))
                 .groupBy(category.id)
                 .fetch());
-    }
-
-    private BooleanExpression notDeleted() {
-        return expenditure.deleted.isFalse();
     }
 
     private BooleanExpression expenditureSearchExpression(String userId, ExpenditureSearchCond searchCond) {
         return userIdEq(userId)
             .and(expenditureDateBetween(searchCond.getStartDate(), searchCond.getEndDate()))
             .and(categoryIdIn(searchCond.getCategories()))
-            .and(amountBetween(searchCond.getMinAmount(), searchCond.getMaxAmount()))
-            .and(notDeleted());
+            .and(amountBetween(searchCond.getMinAmount(), searchCond.getMaxAmount()));
     }
 
     private BooleanExpression userIdEq(String userId) {

--- a/src/main/java/com/wanted/safewallet/domain/user/business/facade/UserFacadeService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/facade/UserFacadeService.java
@@ -31,4 +31,10 @@ public class UserFacadeService {
         User user = userMapper.toEntity(request, encodedPassword);
         userService.saveUser(user);
     }
+
+    @Transactional
+    public void withdrawUser(String userId) {
+        User user = userService.getUser(userId);
+        userService.deleteUser(user);
+    }
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/business/facade/UserFacadeService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/facade/UserFacadeService.java
@@ -33,7 +33,7 @@ public class UserFacadeService {
     }
 
     @Transactional
-    public void withdrawUser(String userId) {
+    public void deactivateUser(String userId) {
         User user = userService.getUser(userId);
         userService.deleteUser(user);
     }

--- a/src/main/java/com/wanted/safewallet/domain/user/business/service/UserSchedulerService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/service/UserSchedulerService.java
@@ -1,0 +1,28 @@
+package com.wanted.safewallet.domain.user.business.service;
+
+import com.wanted.safewallet.domain.budget.business.service.BudgetService;
+import com.wanted.safewallet.domain.expenditure.business.service.ExpenditureService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserSchedulerService {
+
+    private final UserService userService;
+    private final BudgetService budgetService;
+    private final ExpenditureService expenditureService;
+
+    @Scheduled(cron = "0 0 23 ? * SUN *") //매주 일요일 23시마다
+    @Transactional
+    public void withdrawUsers() {
+        List<String> userIds = userService.getWithdrawnUserIds();
+        budgetService.deleteByUserIds(userIds);
+        expenditureService.deleteByUserIds(userIds);
+        userService.withdrawByIds(userIds);
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/user/business/service/UserSchedulerService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/service/UserSchedulerService.java
@@ -17,7 +17,7 @@ public class UserSchedulerService {
     private final BudgetService budgetService;
     private final ExpenditureService expenditureService;
 
-    @Scheduled(cron = "0 0 23 ? * SUN *") //매주 일요일 23시마다
+    @Scheduled(cron = "0 0 23 ? * SUN") //매주 일요일 23시마다
     @Transactional
     public void withdrawUsers() {
         List<String> userIds = userService.getWithdrawnUserIds();

--- a/src/main/java/com/wanted/safewallet/domain/user/business/service/UserService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
         return userRepository.existsByUsername(username);
     }
 
-    @Transactional
+
     public void saveUser(User user) {
         if (!user.getPassword().startsWith(ENCODED_PASSWORD_PREFIX)) {
             throw new BusinessException(PASSWORD_ENCODING_ERROR);
@@ -34,10 +34,20 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @Transactional
+    public void deleteUser(User user) {
+        user.softDelete();
+    }
+
     public void checkForUsername(String username) {
         if (userRepository.existsByUsername(username)) {
             throw new BusinessException(ALREADY_EXISTS_USERNAME);
         }
+    }
+
+    public User getUser(String userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(NOT_FOUND_USER));
     }
 
     public User getUserByUsername(String username) {

--- a/src/main/java/com/wanted/safewallet/domain/user/business/service/UserService.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/business/service/UserService.java
@@ -53,6 +53,16 @@ public class UserService {
         return Optional.of(inactiveUser);
     }
 
+    @Transactional
+    public void withdrawByIds(List<String> ids) {
+        userRepository.deleteAllByIdIn(ids);
+    }
+
+    public List<String> getWithdrawnUserIds() {
+        LocalDateTime minDeletedDate = LocalDate.now().minusMonths(EXPIRY_MONTH).atStartOfDay();
+        return userRepository.findIdsByDeletedAndDeletedDate(minDeletedDate);
+    }
+
     public void checkForUsername(String username) {
         if (userRepository.existsByUsername(username)) {
             throw new BusinessException(ALREADY_EXISTS_USERNAME);

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.UuidGenerator;
 
 @Getter
@@ -28,4 +29,13 @@ public class User extends BaseTime {
 
     @Column(nullable = false)
     private String password;
+
+    @Builder.Default
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Boolean deleted = Boolean.FALSE;
+
+    public void softDelete() {
+        this.deleted = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
@@ -42,4 +42,9 @@ public class User extends BaseTime {
         this.deleted = Boolean.TRUE;
         this.deletedDate = LocalDateTime.now();
     }
+
+    public void restore() {
+        this.deleted = Boolean.FALSE;
+        this.deletedDate = null;
+    }
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/entity/User.java
@@ -4,6 +4,7 @@ import com.wanted.safewallet.global.audit.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,7 +36,10 @@ public class User extends BaseTime {
     @ColumnDefault("0")
     private Boolean deleted = Boolean.FALSE;
 
+    private LocalDateTime deletedDate;
+
     public void softDelete() {
         this.deleted = Boolean.TRUE;
+        this.deletedDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
@@ -1,12 +1,14 @@
 package com.wanted.safewallet.domain.user.persistence.repository;
 
 import com.wanted.safewallet.domain.user.persistence.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface UserRepository extends JpaRepository<User, String> {
+public interface UserRepository extends JpaRepository<User, String>, UserRepositoryCustom {
 
     //Soft Delete 유저의 계정명도 조회 대상
     @Query("SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END FROM User u WHERE u.username = :username")
@@ -20,4 +22,8 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     @Query("select u from User u where u.username = :username and u.deleted = false")
     Optional<User> findByUsername(@Param("username") String username);
+
+    @Modifying
+    @Query("delete from User u where u.id in :ids")
+    void deleteAllByIdIn(@Param("ids") List<String> ids);
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
@@ -15,6 +15,9 @@ public interface UserRepository extends JpaRepository<User, String> {
     @Query("select u from User u where u.id = :userId and u.deleted = false")
     Optional<User> findById(@Param("userId") String userId);
 
+    @Query("select u from User u where u.username = :username and u.deleted = true")
+    Optional<User> findInactiveUserByUsername(@Param("username") String username);
+
     @Query("select u from User u where u.username = :username and u.deleted = false")
     Optional<User> findByUsername(@Param("username") String username);
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepository.java
@@ -8,8 +8,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
+    //Soft Delete 유저의 계정명도 조회 대상
     @Query("SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END FROM User u WHERE u.username = :username")
     boolean existsByUsername(@Param("username") String username);
 
-    Optional<User> findByUsername(String username);
+    @Query("select u from User u where u.id = :userId and u.deleted = false")
+    Optional<User> findById(@Param("userId") String userId);
+
+    @Query("select u from User u where u.username = :username and u.deleted = false")
+    Optional<User> findByUsername(@Param("username") String username);
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.wanted.safewallet.domain.user.persistence.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+    List<String> findIdsByDeletedAndDeletedDate(LocalDateTime minDeletedDate);
+}

--- a/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/persistence/repository/UserRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.wanted.safewallet.domain.user.persistence.repository;
+
+import static com.wanted.safewallet.domain.user.persistence.entity.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findIdsByDeletedAndDeletedDate(LocalDateTime minDeletedDate) {
+        return queryFactory.select(user.id)
+            .from(user)
+            .where(user.deleted.isTrue(),
+                user.deletedDate.before(minDeletedDate))
+            .fetch();
+    }
+}

--- a/src/main/java/com/wanted/safewallet/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/web/controller/UserController.java
@@ -3,10 +3,12 @@ package com.wanted.safewallet.domain.user.web.controller;
 import com.wanted.safewallet.domain.user.business.facade.UserFacadeService;
 import com.wanted.safewallet.domain.user.web.dto.request.UserJoinRequest;
 import com.wanted.safewallet.domain.user.web.dto.response.UsernameCheckResponse;
+import com.wanted.safewallet.global.auth.annotation.CurrentUserId;
 import com.wanted.safewallet.global.dto.response.aop.CommonResponseContent;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,5 +33,10 @@ public class UserController {
     @PostMapping
     public void joinUser(@RequestBody @Valid UserJoinRequest request) {
         userFacadeService.joinUser(request);
+    }
+
+    @DeleteMapping
+    public void withdrawUser(@CurrentUserId String userId) {
+        userFacadeService.withdrawUser(userId);
     }
 }

--- a/src/main/java/com/wanted/safewallet/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/wanted/safewallet/domain/user/web/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
     }
 
     @DeleteMapping
-    public void withdrawUser(@CurrentUserId String userId) {
-        userFacadeService.withdrawUser(userId);
+    public void deactivateUser(@CurrentUserId String userId) {
+        userFacadeService.deactivateUser(userId);
     }
 }

--- a/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/expenditure/business/service/ExpenditureServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
@@ -28,6 +29,7 @@ import com.wanted.safewallet.domain.expenditure.business.dto.ExpenditureUpdateDt
 import com.wanted.safewallet.domain.expenditure.persistence.dto.ExpenditureAmountOfCategoryListDto;
 import com.wanted.safewallet.domain.expenditure.persistence.dto.ExpenditureAmountOfCategoryListDto.ExpenditureAmountOfCategoryDto;
 import com.wanted.safewallet.domain.expenditure.persistence.entity.Expenditure;
+import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureImageRepository;
 import com.wanted.safewallet.domain.expenditure.persistence.repository.ExpenditureRepository;
 import com.wanted.safewallet.global.exception.BusinessException;
 import java.time.LocalDate;
@@ -38,6 +40,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,6 +53,9 @@ class ExpenditureServiceTest {
 
     @Mock
     ExpenditureRepository expenditureRepository;
+
+    @Mock
+    ExpenditureImageRepository expenditureImageRepository;
 
     @DisplayName("지출 내역 수정 서비스 테스트 : 성공")
     @Test
@@ -86,7 +92,9 @@ class ExpenditureServiceTest {
         expenditureService.deleteExpenditure(expenditure);
 
         //then
-        assertThat(expenditure.getDeleted()).isTrue();
+        InOrder inOrder = inOrder(expenditureImageRepository, expenditureRepository);
+        inOrder.verify(expenditureImageRepository, times(1)).deleteAllByExpenditure(expenditure.getId());
+        inOrder.verify(expenditureRepository, times(1)).delete(expenditure);
     }
 
     @DisplayName("지출 통계 서비스 테스트 : 성공")

--- a/src/test/java/com/wanted/safewallet/domain/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/user/business/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.wanted.safewallet.domain.user.business.service;
 
 import static com.wanted.safewallet.global.exception.ErrorCode.ALREADY_EXISTS_USERNAME;
+import static com.wanted.safewallet.global.exception.ErrorCode.NOT_FOUND_USER;
 import static com.wanted.safewallet.global.exception.ErrorCode.PASSWORD_ENCODING_ERROR;
 import static com.wanted.safewallet.utils.Fixtures.anUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,6 +14,8 @@ import static org.mockito.Mockito.times;
 import com.wanted.safewallet.domain.user.persistence.entity.User;
 import com.wanted.safewallet.domain.user.persistence.repository.UserRepository;
 import com.wanted.safewallet.global.exception.BusinessException;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,9 +32,9 @@ class UserServiceTest {
     @Mock
     UserRepository userRepository;
 
-    @DisplayName("유저 회원가입 서비스 테스트 : 실패 - 인코딩되지 않은 비밀번호")
+    @DisplayName("유저 저장 서비스 테스트 : 실패 - 인코딩되지 않은 비밀번호")
     @Test
-    void joinUser() {
+    void saveUser() {
         //given
         String password = "plainPassword";
         User user = anUser().password(password).build();
@@ -40,6 +43,51 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.saveUser(user))
             .isInstanceOf(BusinessException.class)
             .extracting("errorCode").isEqualTo(PASSWORD_ENCODING_ERROR);
+    }
+
+    @DisplayName("유저 삭제 서비스 테스트 : 성공 - Soft Delete 수행")
+    @Test
+    void deleteUser() {
+        //given
+        User user = anUser().build();
+
+        //when
+        userService.deleteUser(user);
+
+        //when
+        assertThat(user.getDeleted()).isTrue();
+        assertThat(user.getDeletedDate()).isNotNull();
+    }
+
+    @DisplayName("기존 비활성 계정 활성화한 후 유저 조회 서비스 테스트 - 비활성 계정 없음")
+    @Test
+    void getRestoredUserByUsername_noInactiveUser() {
+        //given
+        String username = "testUsername";
+        given(userRepository.findInactiveUserByUsername(anyString())).willReturn(Optional.empty());
+
+        //when
+        Optional<User> restoredUser = userService.getRestoredUserByUsername(username);
+
+        //then
+        assertThat(restoredUser).isEmpty();
+    }
+
+    @DisplayName("기존 비활성 계정 활성화한 후 유저 조회 서비스 테스트 - 비활성 계정 복원")
+    @Test
+    void getRestoredUserByUsername_withRestoredUser() {
+        //given
+        User inactiveUser = anUser().deleted(true).deletedDate(LocalDateTime.now()).build();
+        String username = "testUsername";
+        given(userRepository.findInactiveUserByUsername(anyString())).willReturn(Optional.of(inactiveUser));
+
+        //when
+         User restoredUser = userService.getRestoredUserByUsername(username).orElse(null);
+
+        //then
+        assertThat(restoredUser).isNotNull();
+        assertThat(restoredUser.getDeleted()).isFalse();
+        assertThat(restoredUser.getDeletedDate()).isNull();
     }
 
     @DisplayName("유저 계정명 중복 검사 테스트 : 실패")
@@ -54,6 +102,32 @@ class UserServiceTest {
             .isInstanceOf(BusinessException.class)
             .extracting("errorCode").isEqualTo(ALREADY_EXISTS_USERNAME);
         then(userRepository).should(times(1)).existsByUsername(username);
+    }
+
+    @DisplayName("아이디로 유저 조회 서비스 테스트 : 실패 - 해당 유저 없음")
+    @Test
+    void getUser() {
+        //given
+        String userId = "testUserId";
+        given(userRepository.findById(anyString())).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> userService.getUser(userId))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode").isEqualTo(NOT_FOUND_USER);
+    }
+
+    @DisplayName("계정명으로 유저 조회 서비스 테스트 : 실패 - 해당 유저 없음")
+    @Test
+    void getUserByUsername() {
+        //given
+        String username = "testUsername";
+        given(userRepository.findByUsername(anyString())).willReturn(Optional.empty());
+
+        //when, then
+        assertThatThrownBy(() -> userService.getUserByUsername(username))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode").isEqualTo(NOT_FOUND_USER);
     }
 
     @DisplayName("유저 권한 String 값 반환 테스트")

--- a/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -88,6 +89,17 @@ class UserControllerTest extends AbstractRestDocsTest {
                             .generatePopupLink(DocsPopupInfo.PASSWORD_CONSTRAINTS))))));
         then(userFacadeService).should(times(1))
             .joinUser(any(UserJoinRequest.class));
+    }
+
+    @DisplayName("유저 계정 비활성화 컨트롤러 테스트 : 성공")
+    @Test
+    void deactivateUser() throws Exception {
+        //given
+        //when, then
+        restDocsMockMvc.perform(delete("/api/users")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(restDocs.document());
     }
 
     @DisplayName("유저 회원가입 컨트롤러 테스트 : 실패 - 계정명 공백")


### PR DESCRIPTION
## 🚀What's PR?

- `User` 엔티티 Soft Delete 수행 후, 특정 기간(ex. 3개월) 후 해당 유저와 관련된 데이터 모두 삭제 (일단 스케줄러로 매주 일요일 23시마다 수행되도록 구현)
  - 3개월 이내에 재로그인 시 삭제된 계정 복구 (단순히 `deleted` 필드 `true` → `false`로 변경)
  - 3개월 이후에는 `User` 및 관련 `Budget`, `Expenditure` 내역 모두 물리 삭제 처리

## ⚠️Concerns

- `User` 관련 데이터 삭제 시 Spring Data Jpa(영속성 컨텍스트) 사용하지 않고 직접 JPQL 날려 삭제 (전자의 경우 많은 delete 쿼리 + 불필요한 select 쿼리 발생)
  - 즉 관련된 `Budget`, `ExpenditureImage`, `Expenditure` 먼저 싹다 삭제 후 `User` 엔티티 삭제 (이렇게 하지 않으면 FK 제약조건 위배되어 예외 발생)

- 예를 들어 `@OneToMany` 관계인 `Expenditure`, `ExpenditureImage`에 대해 `Expenditure` 엔티티의 `List<ExpenditureImage>` 타입의 `images` 필드에 `CascadeType.REMOVE` 또는 `orphanRemoval = true` 설정 시 하나의 `Expenditure` 삭제하면

  1. 삭제되는 `Expenditure`과 관련된 `ExpenditureImage` select 쿼리
  2. 조회된 `ExpenditureImage` 개수만큼 delete 쿼리 
  3. 1개의 `Expenditure` delete 쿼리
  → 조회되는 `ExpenditureImage` 개수에 따라 매우 많은 쿼리 발생할 수 있음 + 어차피 삭제할 건데 뭐하러 조회?

- 관련된 `ExpenditureImage` JPQL로 직접 삭제 후 `Expenditure` 삭제

  1. 관련된 `ExpenditureImage`를 모두 삭제 ex. `delete from ExpenditureImage ei where ei.expenditure.id = :expenditureId`
  2. 1개의 `Expenditure` delete 쿼리
  → 항상 일정하게 2개의 쿼리만 발생 

**결론**: `CascadeType.REMOVE` 또는 `orphanRemoval = true` 설정으로 인해 엔티티 삭제 성능이 나빠질 수 있음...?

<br/>

🎫**Jira Ticket Number**: [SW-31]

[SW-31]: https://jkde7721.atlassian.net/browse/SW-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ