### PR TITLE
Link 헤더를 이용한 REST Pagination 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
 | 날짜 데이터 요청 및 응답에 대한 역직렬화, 직렬화 | [날짜 데이터를 요청 및 응답으로 주고 받는 여러 가지 방법](https://daeun21dev.tistory.com/38)            |
 | Facade 디자인 패턴 적용             | [Controller - Service 계층 리팩토링 with Facade 패턴](https://daeun21dev.tistory.com/40) |
  | FK 제약 조건이 걸린 테이블 행 삭제 방법     | [부모 엔티티 삭제 시 FK 제약 조건이 걸린 자식 엔티티 처리 방법](https://daeun21dev.tistory.com/41)       | 
-| CI/CD 파이프라인 구축               | 작성 예정                                                                            |
-| Passay 비밀번호 검증기              | 작성 예정                                                                            |
+| 전역적인 CommonResponse 적용 방법    | [AOP로 공통 응답 형식 처리하기](https://daeun21dev.tistory.com/43)                                                                             |
+| REST Pagination 구현 방법        | [Link 헤더를 이용한 REST Pagination 구현](https://daeun21dev.tistory.com/44)                                                                             |
 
 <br/>
 

--- a/src/docs/asciidoc/expenditure-api.adoc
+++ b/src/docs/asciidoc/expenditure-api.adoc
@@ -14,7 +14,7 @@ operation::expenditure-controller-test/get-expenditure-details[snippets="respons
 - 조회된 모든 내용의 `지출 합계`, `카테고리 별 지출 합계` 반환
 - `지출일`, `지출 금액`, `지출 id` 를 기준으로 내림차순 정렬
 
-operation::expenditure-controller-test/search-expenditure[snippets="http-request,query-parameters,response-body,response-fields-data"]
+operation::expenditure-controller-test/search-expenditure[snippets="http-request,query-parameters,http-response,response-headers,response-fields-data"]
 
 === 지출 합계 제외 API
 ==== `GET /api/expenditures/excepts`

--- a/src/main/java/com/wanted/safewallet/global/dto/response/aop/PageStore.java
+++ b/src/main/java/com/wanted/safewallet/global/dto/response/aop/PageStore.java
@@ -1,0 +1,20 @@
+package com.wanted.safewallet.global.dto.response.aop;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PageStore {
+
+    private final ThreadLocal<Page<?>> page = new ThreadLocal<>();
+
+    public void setPage(Page<?> page) {
+        this.page.set(page);
+    }
+
+    public Page<?> getPage() {
+        Page<?> storedPage = this.page.get();
+        this.page.remove();
+        return storedPage;
+    }
+}

--- a/src/main/java/com/wanted/safewallet/global/dto/response/aop/PaginationAdvice.java
+++ b/src/main/java/com/wanted/safewallet/global/dto/response/aop/PaginationAdvice.java
@@ -1,0 +1,20 @@
+package com.wanted.safewallet.global.dto.response.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class PaginationAdvice {
+
+    private final PageStore pageStore;
+
+    @AfterReturning(value = "execution(org.springframework.data.domain.Page com.wanted.safewallet.domain..repository..*.*(..))", returning = "page")
+    public void processPagination(Page<?> page) {
+        pageStore.setPage(page); //ThreadLocal에 저장
+    }
+}

--- a/src/main/java/com/wanted/safewallet/global/dto/response/aop/PaginationLinkHeaderAdvice.java
+++ b/src/main/java/com/wanted/safewallet/global/dto/response/aop/PaginationLinkHeaderAdvice.java
@@ -1,0 +1,79 @@
+package com.wanted.safewallet.global.dto.response.aop;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class PaginationLinkHeaderAdvice implements ResponseBodyAdvice<Object> {
+
+    private final PageStore pageStore;
+
+    @Value("${spring.data.web.pageable.one-indexed-parameters}")
+    private boolean oneIndexedPage;
+
+    private static final String PAGE_PARAM_NAME = "page";
+    private static final String SIZE_PARAM_NAME = "size";
+
+    @Override
+    public boolean supports(MethodParameter returnType,
+        Class<? extends HttpMessageConverter<?>> converterType) {
+        return Arrays.stream(returnType.getExecutable().getParameterTypes())
+            .anyMatch(parameterType -> parameterType.isAssignableFrom(Pageable.class));
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+        Class<? extends HttpMessageConverter<?>> selectedConverterType,
+        ServerHttpRequest request, ServerHttpResponse response) {
+        Page<?> page = pageStore.getPage();
+        response.getHeaders().add(HttpHeaders.LINK, getPageLinks(page));
+        return body;
+    }
+
+    private String getPageLinks(Page<?> page) {
+        if (page == null) return "";
+
+        int pageNumber = page.getNumber() + (oneIndexedPage ? 1 : 0);
+        List<String> links = new ArrayList<>();
+
+        if (!page.isFirst()) {
+            final String firstPageLink = getPageLink(oneIndexedPage ? 1 : 0, page.getSize());
+            links.add("<" + firstPageLink  + ">; rel=\"first\"");
+        }
+        if (page.hasPrevious()) {
+            final String prevPageLink = getPageLink(pageNumber - 1, page.getSize());
+            links.add("<" + prevPageLink + ">; rel=\"prev\"");
+        }
+        if (page.hasNext()) {
+            final String nextPageLink = getPageLink(pageNumber + 1, page.getSize());
+            links.add("<" + nextPageLink + ">; rel=\"next\"");
+        }
+        if (!page.isLast()) {
+            final String lastPageLink = getPageLink(page.getTotalPages() - (oneIndexedPage ? 0 : 1), page.getSize());
+            links.add("<" + lastPageLink + ">; rel=\"last\"");
+        }
+        return String.join(",", links);
+    }
+
+    private String getPageLink(int page, int size) {
+        return ServletUriComponentsBuilder.fromCurrentRequest()
+            .replaceQueryParam(PAGE_PARAM_NAME, page)
+            .replaceQueryParam(SIZE_PARAM_NAME, size)
+            .build().encode().toUriString();
+    }
+}

--- a/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/enums/EnumDocsControllerTest.java
@@ -13,6 +13,7 @@ import com.wanted.safewallet.docs.common.AbstractRestDocsTest;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import com.wanted.safewallet.domain.expenditure.business.enums.FinanceStatus;
 import com.wanted.safewallet.domain.expenditure.web.enums.StatsCriteria;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -21,11 +22,13 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(EnumDocsController.class)
 class EnumDocsControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/docs/common/paging/PagingDocsControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/paging/PagingDocsControllerTest.java
@@ -6,12 +6,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wanted.safewallet.docs.common.AbstractRestDocsTest;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(PagingDocsController.class)
 class PagingDocsControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/docs/common/response/CommonResponseControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/docs/common/response/CommonResponseControllerTest.java
@@ -7,12 +7,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wanted.safewallet.docs.common.AbstractRestDocsTest;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(CommonResponseController.class)
 class CommonResponseControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/domain/auth/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/auth/web/controller/AuthControllerTest.java
@@ -32,6 +32,7 @@ import com.wanted.safewallet.domain.auth.config.AuthTestConfig;
 import com.wanted.safewallet.domain.auth.utils.JwtProperties;
 import com.wanted.safewallet.domain.auth.web.dto.request.LoginRequest;
 import com.wanted.safewallet.domain.user.persistence.entity.User;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@Import(AuthTestConfig.class)
+@Import({AuthTestConfig.class, PageStore.class})
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends AbstractRestDocsTest {
 

--- a/src/test/java/com/wanted/safewallet/domain/budget/web/controller/BudgetControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/budget/web/controller/BudgetControllerTest.java
@@ -43,6 +43,7 @@ import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponse;
 import com.wanted.safewallet.domain.budget.web.dto.response.BudgetSetUpResponse.BudgetOfCategoryResponse;
 import com.wanted.safewallet.domain.budget.web.dto.response.BudgetUpdateResponse;
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import java.time.YearMonth;
 import java.util.List;
@@ -52,9 +53,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(BudgetController.class)
 class BudgetControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/category/web/controller/CategoryControllerTest.java
@@ -18,14 +18,17 @@ import com.wanted.safewallet.domain.category.business.facade.CategoryFacadeServi
 import com.wanted.safewallet.domain.category.persistence.entity.CategoryType;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponse;
 import com.wanted.safewallet.domain.category.web.dto.response.CategoryListResponse.CategoryResponse;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(CategoryController.class)
 class CategoryControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserControllerTest.java
@@ -27,15 +27,18 @@ import com.wanted.safewallet.domain.user.business.facade.UserFacadeService;
 import com.wanted.safewallet.domain.user.web.dto.request.UserJoinRequest;
 import com.wanted.safewallet.domain.user.web.dto.request.UserMailRequest;
 import com.wanted.safewallet.domain.user.web.dto.response.UsernameCheckResponse;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(UserController.class)
 class UserControllerTest extends AbstractRestDocsTest {

--- a/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserMailControllerTest.java
+++ b/src/test/java/com/wanted/safewallet/domain/user/web/controller/UserMailControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import com.wanted.safewallet.domain.user.business.facade.UserFacadeService;
+import com.wanted.safewallet.global.dto.response.aop.PageStore;
 import com.wanted.safewallet.global.exception.BusinessException;
 import com.wanted.safewallet.utils.auth.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
@@ -18,9 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+@Import(PageStore.class)
 @WithMockCustomUser
 @WebMvcTest(UserMailController.class)
 class UserMailControllerTest {


### PR DESCRIPTION
## 🚀What's PR?

- `Link` 헤더를 이용해 REST API의 규약인 HATEOAS 구현

## ⚠️Concerns

- `ResponseBodyAdvice` 인터페이스를 구현하여 `ServerHttpResponse` 응답 객체에 `Link` 헤더 값을 설정 
- 응답 헤더에 다음과 같이 추가
  ```
  HTTP/1.1 200 OK
  Link: <http://localhost:8080/api/expenditures?page=1&size=3>; rel="first",<http://localhost:8080/api/expenditures?page=1&size=3>; rel="prev",<http://localhost:8080/api/expenditures?page=3&size=3>; rel="next",<http://localhost:8080/api/expenditures?page=4&size=3>; rel="last"
  ```
- 프론트에서 이거 어떻게 사용하지?

<br/>

🎫**Jira Ticket Number**: [SW-34]

[SW-34]: https://jkde7721.atlassian.net/browse/SW-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ